### PR TITLE
Add nested categories resource under settings/finance namespace

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -18,8 +18,8 @@ class CategoriesController < ApplicationController
 
     respond_to do |format|
       if @category.save
-        format.html { redirect_to @category, notice: t("categories.flash.created") }
-        format.json { render :show, status: :created, location: @category }
+        format.html { redirect_to settings_finance_category_path(@category), notice: t("categories.flash.created") }
+        format.json { render :show, status: :created, location: settings_finance_category_path(@category) }
       else
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @category.errors, status: :unprocessable_entity }
@@ -33,8 +33,8 @@ class CategoriesController < ApplicationController
   def update
     respond_to do |format|
       if @category.update(category_params)
-        format.html { redirect_to @category, notice: t("categories.flash.updated") }
-        format.json { render :show, status: :ok, location: @category }
+        format.html { redirect_to settings_finance_category_path(@category), notice: t("categories.flash.updated") }
+        format.json { render :show, status: :ok, location: settings_finance_category_path(@category) }
       else
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @category.errors, status: :unprocessable_entity }
@@ -46,7 +46,7 @@ class CategoriesController < ApplicationController
     @category.destroy!
 
     respond_to do |format|
-      format.html { redirect_to categories_path, status: :see_other, notice: t("categories.flash.destroyed") }
+      format.html { redirect_to settings_finance_categories_path, status: :see_other, notice: t("categories.flash.destroyed") }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,11 +1,14 @@
 class SettingsController < ApplicationController
   def edit
+    @section = settings_section
+    @category_count = Category.for_account(Current.account).count if @section == "finance" && Current.account.present?
   end
 
   def update
     if Current.user.update(settings_params)
-      redirect_to edit_settings_path, notice: t("settings.updated")
+      redirect_to edit_settings_path(section: "general"), notice: t("settings.updated")
     else
+      @section = "general"
       render :edit, status: :unprocessable_entity
     end
   end
@@ -14,5 +17,10 @@ class SettingsController < ApplicationController
 
   def settings_params
     params.require(:user).permit(:locale)
+  end
+
+  def settings_section
+    section = params[:section].presence_in(%w[general finance])
+    section || "general"
   end
 end

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_with model: @category, local: true do |form| %>
+<% form_url = @category.persisted? ? settings_finance_category_path(@category) : settings_finance_categories_path %>
+<% form_method = @category.persisted? ? :patch : :post %>
+<%= form_with model: @category, url: form_url, method: form_method, local: true do |form| %>
   <% if @category.errors.any? %>
     <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= t("shared.errors_prohibited_save", count: @category.errors.count, resource: t("activerecord.models.category").downcase) %></h2>
@@ -17,7 +19,7 @@
 
   <div class="mb-4">
     <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to t("shared.cancel"), @category.persisted? ? @category : categories_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= link_to t("shared.cancel"), @category.persisted? ? settings_finance_category_path(@category) : settings_finance_categories_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="mb-4 flex justify-between items-center">
   <%= render Ui::ButtonComponent.new(
-      href: new_category_path,
+      href: new_settings_finance_category_path,
       label: t("categories.new_category"),
       variant: "default"
     ) %>
@@ -22,9 +22,9 @@
       <tr class="border-t">
         <td class="px-4 py-2"><%= category.name %></td>
         <td class="px-4 py-2">
-          <%= link_to t("shared.view"), category, class: "text-blue-500 hover:underline" %>
-          <%= link_to t("shared.edit"), edit_category_path(category), class: "text-blue-500 hover:underline ml-2" %>
-          <%= link_to t("shared.delete"), category, method: :delete, data: { confirm: t("shared.confirm_destroy_category") }, class: "text-red-500 hover:underline ml-2" %>
+          <%= link_to t("shared.view"), settings_finance_category_path(category), class: "text-blue-500 hover:underline" %>
+          <%= link_to t("shared.edit"), edit_settings_finance_category_path(category), class: "text-blue-500 hover:underline ml-2" %>
+          <%= link_to t("shared.delete"), settings_finance_category_path(category), method: :delete, data: { confirm: t("shared.confirm_destroy_category") }, class: "text-red-500 hover:underline ml-2" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,15 +1,15 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← " + t("categories.show.back"), categories_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← " + t("categories.show.back"), settings_finance_categories_path, class: "text-blue-500 hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @category.name %></h1>
 
 <div class="mb-4 flex space-x-2">
-  <%= render Ui::ButtonComponent.new(href: edit_category_path(@category), label: "Edit", variant: "outline") %>
+  <%= render Ui::ButtonComponent.new(href: edit_settings_finance_category_path(@category), label: "Edit", variant: "outline") %>
   <%= render Ui::ButtonComponent.new(
-    href: @category,
+    href: settings_finance_category_path(@category),
     label: "Delete",
     variant: "destructive",
     method: :delete,

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -39,7 +39,7 @@
     <p><%= t("dashboard.expenses_description") %></p>
   <% end %>
 
-  <%= link_to categories_path, class: "block p-4 border rounded hover:shadow" do %>
+  <%= link_to settings_finance_categories_path, class: "block p-4 border rounded hover:shadow" do %>
     <h2 class="text-xl">🏷️ <%= t("dashboard.categories_title") %></h2>
     <p><%= t("dashboard.categories_description") %></p>
   <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -26,7 +26,6 @@
         <%= link_to t("nav.budgets"), budget_periods_path, class: controller_path == "budget_periods" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
         <%= link_to t("nav.incomes"), income_events_path, class: controller_path == "income_events" || controller_path == "planned_expenses" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
         <%= link_to t("nav.expenses"), expenses_path, class: controller_path == "expenses" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to t("nav.categories"), categories_path, class: controller_path == "categories" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
         <%= link_to t("nav.tasks"), task_recurring_tasks_path, class: controller_path.include?("task") ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
         <%= link_to "Projects", projects_projects_path, class: controller_path == "projects/projects" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
         <%= link_to "Docs", projects_docs_path, class: controller_path == "projects/standalone_docs" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
@@ -48,7 +47,7 @@
             </div>
             <%= link_to t("nav.accounts"), accounts_path, class: "text-sm #{controller_path == "accounts" || controller_path == "account_memberships" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
           <% end %>
-          <%= link_to t("nav.settings"), edit_settings_path, class: "text-sm #{controller_path == "settings" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
+          <%= link_to t("nav.settings"), edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), class: "text-sm #{controller_path == "settings" || controller_path == "categories" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
           <%= link_to session_path, data: { turbo_method: :delete }, class: "px-4 py-2 bg-gray-500 text-white text-sm rounded-lg hover:bg-gray-600 transition-colors" do %>
             <%= t("nav.log_out") %>
           <% end %>
@@ -75,7 +74,6 @@
         <%= link_to t("nav.budgets"), budget_periods_path, class: "py-2 #{controller_path == "budget_periods" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
         <%= link_to t("nav.incomes"), income_events_path, class: "py-2 #{controller_path == "income_events" || controller_path == "planned_expenses" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
         <%= link_to t("nav.expenses"), expenses_path, class: "py-2 #{controller_path == "expenses" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to t("nav.categories"), categories_path, class: "py-2 #{controller_path == "categories" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
         <%= link_to t("nav.tasks"), task_recurring_tasks_path, class: "py-2 #{controller_path.include?("task") ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
         <%= link_to "Projects", projects_projects_path, class: "py-2 #{controller_path == "projects/projects" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
         <%= link_to "Docs", projects_docs_path, class: "py-2 #{controller_path == "projects/standalone_docs" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
@@ -98,7 +96,7 @@
             </div>
             <%= link_to t("nav.accounts"), accounts_path, class: "py-2 text-sm #{controller_path == "accounts" || controller_path == "account_memberships" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
           <% end %>
-          <%= link_to t("nav.settings"), edit_settings_path, class: "py-2 text-sm #{controller_path == "settings" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
+          <%= link_to t("nav.settings"), edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), class: "py-2 text-sm #{controller_path == "settings" || controller_path == "categories" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
           <%= link_to session_path, data: { turbo_method: :delete }, class: "px-4 py-2 bg-gray-500 text-white text-sm rounded-lg hover:bg-gray-600 transition-colors inline-block w-fit" do %>
             <%= t("nav.log_out") %>
           <% end %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -2,32 +2,74 @@
 <div class="container mx-auto px-4 py-6">
   <h1 class="text-2xl font-bold mb-4"><%= t("settings.title") %></h1>
 
-  <%= form_with model: Current.user, url: settings_path, method: :patch, local: true do |f| %>
-    <% if Current.user.errors.any? %>
-      <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded">
-        <h2 class="font-bold text-red-800"><%= pluralize(Current.user.errors.count, "error") %> prohibited settings from being updated:</h2>
-        <ul class="list-disc list-inside text-red-700">
-          <% Current.user.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
-          <% end %>
-        </ul>
+  <nav class="mb-6 border-b border-gray-200" aria-label="Settings sections">
+    <div class="flex gap-4">
+      <%= link_to t("settings.sections.general"),
+          edit_settings_path(section: "general"),
+          class: "pb-2 border-b-2 #{@section == "general" ? "border-blue-500 text-blue-700 font-semibold" : "border-transparent text-gray-600 hover:text-gray-900"}" %>
+      <%= link_to t("settings.sections.finance"),
+          edit_settings_path(section: "finance"),
+          class: "pb-2 border-b-2 #{@section == "finance" ? "border-blue-500 text-blue-700 font-semibold" : "border-transparent text-gray-600 hover:text-gray-900"}" %>
+    </div>
+  </nav>
+
+  <% if @section == "finance" %>
+    <section class="space-y-4">
+      <div>
+        <h2 class="text-xl font-semibold"><%= t("settings.finance.title") %></h2>
+        <p class="text-gray-600"><%= t("settings.finance.description") %></p>
       </div>
-    <% end %>
 
-    <div class="mb-4">
-      <%= f.label :locale, t("settings.language"), class: "block text-sm font-medium text-gray-700 mb-1" %>
-      <%= f.select :locale,
-          options_for_select(
-            I18n.available_locales.map { |l| [t("locales.#{l}"), l.to_s] },
-            Current.user.locale
-          ),
-          {},
-          class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
-    </div>
+      <div class="border rounded-lg p-4 bg-white">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h3 class="font-semibold"><%= t("settings.finance.categories_title") %></h3>
+            <p class="text-sm text-gray-600"><%= t("settings.finance.categories_description") %></p>
+            <p class="text-sm text-gray-500 mt-1"><%= t("settings.finance.category_count", count: @category_count || 0) %></p>
+          </div>
+          <%= render Ui::ButtonComponent.new(
+              href: settings_finance_categories_path,
+              label: t("settings.finance.manage_categories"),
+              variant: "outline"
+            ) %>
+        </div>
+      </div>
+    </section>
+  <% else %>
+    <section class="space-y-4">
+      <div>
+        <h2 class="text-xl font-semibold"><%= t("settings.general.title") %></h2>
+        <p class="text-gray-600"><%= t("settings.general.description") %></p>
+      </div>
 
-    <div class="flex space-x-2">
-      <%= f.submit t("settings.update"), class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-      <%= render Ui::ButtonComponent.new(href: root_path, label: t("settings.cancel"), variant: "ghost") %>
-    </div>
+      <%= form_with model: Current.user, url: settings_path, method: :patch, local: true do |f| %>
+        <% if Current.user.errors.any? %>
+          <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded">
+            <h2 class="font-bold text-red-800"><%= pluralize(Current.user.errors.count, "error") %> prohibited settings from being updated:</h2>
+            <ul class="list-disc list-inside text-red-700">
+              <% Current.user.errors.full_messages.each do |message| %>
+                <li><%= message %></li>
+              <% end %>
+            </ul>
+          </div>
+        <% end %>
+
+        <div class="mb-4">
+          <%= f.label :locale, t("settings.language"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.select :locale,
+              options_for_select(
+                I18n.available_locales.map { |l| [t("locales.#{l}"), l.to_s] },
+                Current.user.locale
+              ),
+              {},
+              class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        </div>
+
+        <div class="flex space-x-2">
+          <%= f.submit t("settings.update"), class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+          <%= render Ui::ButtonComponent.new(href: root_path, label: t("settings.cancel"), variant: "ghost") %>
+        </div>
+      <% end %>
+    </section>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -196,6 +196,21 @@ en:
 
   settings:
     title: "Settings"
+    sections:
+      general: "General"
+      finance: "Finance"
+    general:
+      title: "General settings"
+      description: "Manage account-wide preferences like language."
+    finance:
+      title: "Finance settings"
+      description: "Configure the core finance domain used for planning, budgeting, and expense tracking."
+      categories_title: "Categories"
+      categories_description: "Define the category taxonomy used across budgets, plans, and expenses."
+      category_count:
+        one: "1 category"
+        other: "%{count} categories"
+      manage_categories: "Manage categories"
     language: "Language"
     update: "Save changes"
     updated: "Settings updated."

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -196,6 +196,21 @@ es:
 
   settings:
     title: "Ajustes"
+    sections:
+      general: "General"
+      finance: "Finanzas"
+    general:
+      title: "Ajustes generales"
+      description: "Gestiona preferencias de la cuenta, como el idioma."
+    finance:
+      title: "Ajustes financieros"
+      description: "Configura el dominio financiero base para planificación, presupuestos y seguimiento de gastos."
+      categories_title: "Categorías"
+      categories_description: "Define la taxonomía de categorías usada en presupuestos, planes y gastos."
+      category_count:
+        one: "1 categoría"
+        other: "%{count} categorías"
+      manage_categories: "Gestionar categorías"
     language: "Idioma"
     update: "Guardar cambios"
     updated: "Ajustes actualizados."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,10 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :categories
+  get "categories", to: redirect("/settings/finance/categories")
+  get "categories/new", to: redirect("/settings/finance/categories/new")
+  get "categories/:id", to: redirect { |params, _request| "/settings/finance/categories/#{params[:id]}" }
+  get "categories/:id/edit", to: redirect { |params, _request| "/settings/finance/categories/#{params[:id]}/edit" }
   resources :expenses
 
   resources :shopping_items do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,11 @@ Rails.application.routes.draw do
   resource :session
   resource :registration, only: [ :new, :create ]
   resource :settings, only: [ :edit, :update ]
+  namespace :settings do
+    namespace :finance do
+      resources :categories, controller: "/categories"
+    end
+  end
   resources :passwords, param: :token
   get "dashboard/index"
   # resources :budget_line_items

--- a/test/integration/legacy_categories_redirect_test.rb
+++ b/test/integration/legacy_categories_redirect_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class LegacyCategoriesRedirectTest < ActionDispatch::IntegrationTest
+  test "legacy categories index redirects to finance namespace" do
+    get "/categories"
+
+    assert_response :redirect
+    assert_redirected_to settings_finance_categories_path
+  end
+
+  test "legacy categories new redirects to finance namespace" do
+    get "/categories/new"
+
+    assert_response :redirect
+    assert_redirected_to new_settings_finance_category_path
+  end
+
+  test "legacy categories show redirects to finance namespace" do
+    category = categories(:one)
+
+    get "/categories/#{category.id}"
+
+    assert_response :redirect
+    assert_redirected_to settings_finance_category_path(category)
+  end
+
+  test "legacy categories edit redirects to finance namespace" do
+    category = categories(:one)
+
+    get "/categories/#{category.id}/edit"
+
+    assert_response :redirect
+    assert_redirected_to edit_settings_finance_category_path(category)
+  end
+end

--- a/test/integration/settings_finance_navigation_test.rb
+++ b/test/integration/settings_finance_navigation_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class SettingsFinanceNavigationTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:one)
+    @account = accounts(:one)
+  end
+
+  def sign_in
+    post session_path, params: {
+      email_address: @user.email_address,
+      password: "password"
+    }
+    Current.account = @account
+  end
+
+  def teardown
+    Current.account = nil
+    Current.session = nil
+  end
+
+  test "main navbar does not include categories link" do
+    sign_in
+
+    get root_path
+
+    assert_response :success
+    assert_select "header nav a", text: I18n.t("nav.categories"), count: 0
+  end
+
+  test "settings finance section links to categories management" do
+    sign_in
+
+    get edit_settings_path(section: "finance")
+
+    assert_response :success
+    assert_select "h2", text: I18n.t("settings.finance.title")
+    assert_select "a[href='#{settings_finance_categories_path}']", text: I18n.t("settings.finance.manage_categories")
+  end
+end


### PR DESCRIPTION


### Title

**feat: move categories to settings/finance and introduce settings sections**

---

### Description

This PR reorganizes category management under the `settings/finance` namespace and introduces a section-based settings UI.

---

### Changes

* Add nested `settings/finance/categories` routes
* Introduce settings sections (`general`, `finance`) with navigation
* Move category management UI into **Settings → Finance**
* Update all category-related paths (controllers, views, dashboard) to use the new namespace
* Add redirects from legacy `/categories` routes for backward compatibility
* Remove categories link from main navbar and surface it via settings
* Enhance `SettingsController` to handle active section and category count
* Add i18n support for new settings structure (EN/ES)
* Add integration tests for:

  * Legacy route redirects
  * Settings finance navigation

---

### Benefits

* Improves domain organization by grouping finance-related features
* Centralizes category management under settings
* Maintains backward compatibility via redirects
* Enhances navigation clarity and scalability of settings

---

### Notes

* Legacy `/categories` routes are preserved via redirects
* No breaking changes expected for users

