### PR TITLE
Income event loan schedule

### DIFF
--- a/app/controllers/income_events_controller.rb
+++ b/app/controllers/income_events_controller.rb
@@ -33,6 +33,9 @@ class IncomeEventsController < ApplicationController
   def show
     @planned_expenses = @income_event.planned_expenses_ordered
     @direct_expenses = @income_event.expenses.where(planned_expense_id: nil).order(date: :desc)
+    @loan_payment_schedules = @income_event.loan_payment_schedules_ordered if @income_event.loan?
+    @pending_liabilities = Financial::Liability.for_account(Current.account).active.select { |liability| liability.current_balance.positive? }
+    @active_financial_accounts = Financial::Asset.for_account(Current.account).active.order(:name)
   end
 
   def new

--- a/app/controllers/income_events_controller.rb
+++ b/app/controllers/income_events_controller.rb
@@ -1,5 +1,5 @@
 class IncomeEventsController < ApplicationController
-  before_action :set_income_event, only: [ :show, :edit, :update, :destroy, :receive, :apply_all ]
+  before_action :set_income_event, only: [ :show, :edit, :update, :destroy, :receive, :apply_all, :loan_summary, :pay_liability ]
   before_action :set_budget_period, only: [ :index, :new, :create ]
 
   def index
@@ -36,6 +36,12 @@ class IncomeEventsController < ApplicationController
     @loan_payment_schedules = @income_event.loan_payment_schedules_ordered if @income_event.loan?
     @pending_liabilities = Financial::Liability.for_account(Current.account).active.select { |liability| liability.current_balance.positive? }
     @active_financial_accounts = Financial::Asset.for_account(Current.account).active.order(:name)
+  end
+
+  def loan_summary
+    @loan_payment_schedules = @income_event.loan_payment_schedules_ordered
+    @planned_expenses = @income_event.planned_expenses_ordered
+    @direct_expenses = @income_event.expenses.where(planned_expense_id: nil).order(date: :desc)
   end
 
   def new
@@ -97,6 +103,26 @@ class IncomeEventsController < ApplicationController
     redirect_to @income_event, notice: t("income_events.flash.applied_all")
   end
 
+  def pay_liability
+    liability = Financial::Liability.for_account(Current.account).find_by(id: liability_payment_params[:financial_liability_id])
+    source_account = Financial::Asset.for_account(Current.account).active.find_by(id: liability_payment_params[:financial_account_id])
+
+    service = Financial::Liabilities::RecordPaymentService.call(
+      liability: liability,
+      source_account: source_account,
+      amount: liability_payment_params[:amount],
+      description: liability_payment_params[:description].presence || "Payment from #{@income_event.description}",
+      entry_date: liability_payment_params[:entry_date],
+      income_event: @income_event
+    )
+
+    if service.success?
+      redirect_to @income_event, notice: "Liability payment applied"
+    else
+      redirect_to @income_event, alert: service.error_message
+    end
+  end
+
   private
 
   def set_income_event
@@ -108,10 +134,34 @@ class IncomeEventsController < ApplicationController
   end
 
   def income_event_params
-    params.expect(income_event: [ :expected_date, :expected_amount, :description, :status, :budget_period_id ])
+    params.expect(income_event: [
+      :expected_date,
+      :expected_amount,
+      :description,
+      :status,
+      :budget_period_id,
+      :income_type,
+      :loan_amount,
+      :interest_rate,
+      :number_of_payments,
+      :payment_frequency,
+      :payment_amount,
+      :lender_name,
+      :notes
+    ])
   end
 
   def receive_params
     params.expect(income_event: [ :received_date, :received_amount ])
+  end
+
+  def liability_payment_params
+    params.expect(income_event_liability_payment: [
+      :financial_liability_id,
+      :financial_account_id,
+      :amount,
+      :entry_date,
+      :description
+    ])
   end
 end

--- a/app/javascript/controllers/income_event_form_controller.js
+++ b/app/javascript/controllers/income_event_form_controller.js
@@ -1,0 +1,262 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "incomeTypeSelect",
+    "loanFields",
+    "expectedAmountField",
+    "loanAmountField",
+    "interestRateField",
+    "numberOfPaymentsField",
+    "paymentFrequencyField",
+    "paymentAmountField",
+    "interestHint"
+  ]
+
+  connect() {
+    this.syncing = false
+    this.lastEdited = null
+    this.userEditedInterest = this.hasInterestRateFieldTarget && this.interestRateFieldTarget.value.trim() !== ""
+    this.toggleLoanFields()
+    this.syncFromCurrentState()
+  }
+
+  toggleLoanFields() {
+    if (!this.hasIncomeTypeSelectTarget || !this.hasLoanFieldsTarget) return
+
+    const isLoan = this.incomeTypeSelectTarget.value === "loan"
+
+    this.loanFieldsTarget.classList.toggle("hidden", !isLoan)
+
+    if (this.hasExpectedAmountFieldTarget) {
+      this.expectedAmountFieldTarget.classList.toggle("hidden", isLoan)
+    }
+
+    if (!isLoan) {
+      this.hideInterestHint()
+      return
+    }
+
+    this.syncFromCurrentState()
+  }
+
+  onSharedTermsChanged() {
+    if (this.syncing) return
+    this.syncFromCurrentState()
+  }
+
+  onPaymentInput() {
+    if (this.syncing) return
+    this.lastEdited = "payment"
+    this.syncFromPayment(true)
+  }
+
+  onInterestInput() {
+    if (this.syncing) return
+    if (!this.hasInterestRateFieldTarget) return
+
+    const currentValue = this.interestRateFieldTarget.value.trim()
+    this.userEditedInterest = currentValue !== ""
+    this.lastEdited = "interest"
+
+    if (this.userEditedInterest) {
+      this.interestRateFieldTarget.dataset.estimated = "false"
+      this.syncFromInterest()
+    } else {
+      this.syncFromCurrentState()
+    }
+  }
+
+  syncFromCurrentState() {
+    if (!this.isLoanSelected()) return
+
+    if (this.lastEdited === "interest") {
+      if (!this.syncFromInterest()) this.syncFromPayment()
+      return
+    }
+
+    if (this.lastEdited === "payment") {
+      if (!this.syncFromPayment(true)) this.syncFromInterest()
+      return
+    }
+
+    const paymentValue = this.hasPaymentAmountFieldTarget ? this.paymentAmountFieldTarget.value.trim() : ""
+    const interestValue = this.hasInterestRateFieldTarget ? this.interestRateFieldTarget.value.trim() : ""
+
+    if (paymentValue !== "") {
+      if (!this.syncFromPayment(true)) this.syncFromInterest()
+      return
+    }
+
+    if (interestValue !== "") {
+      this.syncFromInterest()
+      return
+    }
+
+    this.hideInterestHint()
+  }
+
+  syncFromPayment(forceOverrideInterest = false) {
+    if (!this.isLoanSelected()) return
+    if (!this.hasLoanAmountFieldTarget || !this.hasNumberOfPaymentsFieldTarget || !this.hasPaymentAmountFieldTarget || !this.hasPaymentFrequencyFieldTarget) {
+      return false
+    }
+
+    const principal = this.parseNumber(this.loanAmountFieldTarget.value)
+    const numberOfPayments = this.parseInteger(this.numberOfPaymentsFieldTarget.value)
+    const paymentAmount = this.parseNumber(this.paymentAmountFieldTarget.value)
+    const paymentFrequency = this.paymentFrequencyFieldTarget.value
+
+    if (!principal || !numberOfPayments || !paymentAmount || !paymentFrequency) {
+      this.hideInterestHint()
+      return false
+    }
+
+    if (paymentAmount * numberOfPayments < principal) {
+      this.showInterestHint("Payment amount is too low for the selected number of payments", true)
+      return false
+    }
+
+    const annualRate = this.inferAnnualRate(principal, paymentAmount, numberOfPayments, paymentFrequency)
+
+    if (forceOverrideInterest || this.shouldAutofillInterest()) {
+      this.userEditedInterest = false
+      this.syncing = true
+      this.interestRateFieldTarget.value = annualRate.toFixed(3)
+      this.interestRateFieldTarget.dataset.estimated = "true"
+      this.syncing = false
+    }
+
+    this.showInterestHint(`Estimated annual interest rate: ${annualRate.toFixed(3)}%`, false)
+    return true
+  }
+
+  syncFromInterest() {
+    if (!this.isLoanSelected()) return false
+    if (!this.hasLoanAmountFieldTarget || !this.hasNumberOfPaymentsFieldTarget || !this.hasInterestRateFieldTarget || !this.hasPaymentFrequencyFieldTarget || !this.hasPaymentAmountFieldTarget) {
+      return false
+    }
+
+    const principal = this.parseNumber(this.loanAmountFieldTarget.value)
+    const numberOfPayments = this.parseInteger(this.numberOfPaymentsFieldTarget.value)
+    const annualRate = this.parseNonNegativeNumber(this.interestRateFieldTarget.value)
+    const paymentFrequency = this.paymentFrequencyFieldTarget.value
+
+    if (!principal || !numberOfPayments || annualRate === null || !paymentFrequency) {
+      this.hideInterestHint()
+      return false
+    }
+
+    const paymentAmount = this.computePaymentAmount(principal, annualRate, numberOfPayments, paymentFrequency)
+
+    this.syncing = true
+    this.paymentAmountFieldTarget.value = paymentAmount.toFixed(2)
+    this.syncing = false
+
+    this.showInterestHint(`Payment amount updated from annual interest rate: ${annualRate.toFixed(3)}%`, false)
+    return true
+  }
+
+  shouldAutofillInterest() {
+    if (!this.hasInterestRateFieldTarget) return false
+
+    const field = this.interestRateFieldTarget
+    const isEstimated = field.dataset.estimated === "true"
+    return !this.userEditedInterest || isEstimated || field.value.trim() === ""
+  }
+
+  inferAnnualRate(principal, paymentAmount, numberOfPayments, paymentFrequency) {
+    const periodsPerYear = this.periodsPerYear(paymentFrequency)
+
+    if (paymentAmount * numberOfPayments <= principal) {
+      return 0
+    }
+
+    const periodicRate = this.solvePeriodicRate(principal, paymentAmount, numberOfPayments)
+    return periodicRate * periodsPerYear * 100
+  }
+
+  computePaymentAmount(principal, annualRate, numberOfPayments, paymentFrequency) {
+    const periodsPerYear = this.periodsPerYear(paymentFrequency)
+    const periodicRate = (annualRate / 100) / periodsPerYear
+
+    if (periodicRate === 0) {
+      return principal / numberOfPayments
+    }
+
+    const numerator = principal * periodicRate
+    const denominator = 1 - Math.pow(1 + periodicRate, -numberOfPayments)
+    return numerator / denominator
+  }
+
+  solvePeriodicRate(principal, paymentAmount, periods) {
+    let low = 0.0
+    let high = 1.0
+
+    while (this.paymentForRate(principal, high, periods) < paymentAmount) {
+      high *= 2
+      if (high > 100) break
+    }
+
+    for (let i = 0; i < 80; i += 1) {
+      const mid = (low + high) / 2.0
+      const computedPayment = this.paymentForRate(principal, mid, periods)
+
+      if (computedPayment < paymentAmount) {
+        low = mid
+      } else {
+        high = mid
+      }
+    }
+
+    return (low + high) / 2.0
+  }
+
+  paymentForRate(principal, rate, periods) {
+    if (rate === 0) return principal / periods
+
+    const numerator = principal * rate
+    const denominator = 1 - Math.pow(1 + rate, -periods)
+    return numerator / denominator
+  }
+
+  periodsPerYear(frequency) {
+    if (frequency === "weekly") return 52.0
+    if (frequency === "biweekly") return 26.0
+    if (frequency === "quincenal") return 365.0 / 15.0
+    return 12.0
+  }
+
+  parseNumber(value) {
+    const parsed = parseFloat(value)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  }
+
+  parseNonNegativeNumber(value) {
+    const parsed = parseFloat(value)
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null
+  }
+
+  parseInteger(value) {
+    const parsed = parseInt(value, 10)
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+  }
+
+  isLoanSelected() {
+    return this.hasIncomeTypeSelectTarget && this.incomeTypeSelectTarget.value === "loan"
+  }
+
+  showInterestHint(message, isError) {
+    if (!this.hasInterestHintTarget) return
+
+    this.interestHintTarget.textContent = message
+    this.interestHintTarget.classList.remove("hidden", "text-gray-500", "text-red-600", "text-emerald-600")
+    this.interestHintTarget.classList.add(isError ? "text-red-600" : "text-emerald-600")
+  }
+
+  hideInterestHint() {
+    if (!this.hasInterestHintTarget) return
+
+    this.interestHintTarget.classList.add("hidden")
+  }
+}

--- a/app/models/income_event.rb
+++ b/app/models/income_event.rb
@@ -3,15 +3,30 @@ class IncomeEvent < ApplicationRecord
   belongs_to :budget_period, optional: true
   has_many :planned_expenses, dependent: :destroy
   has_many :expenses, dependent: :nullify
+  has_many :loan_payment_schedules, foreign_key: :loan_id, dependent: :destroy
 
   before_validation :set_account, on: :create
+  before_validation :normalize_payment_frequency
+  before_validation :apply_loan_defaults
+  before_validation :infer_loan_interest_rate
+  after_save :refresh_loan_payment_schedules, if: :loan?
 
   scope :for_account, ->(account) { where(account: account) }
+  scope :regular, -> { where(income_type: "regular") }
+  scope :loans, -> { where(income_type: "loan") }
 
   validates :expected_date, presence: true
   validates :expected_amount, presence: true, numericality: { greater_than: 0 }
   validates :description, presence: true
   validates :status, presence: true, inclusion: { in: %w[pending received applied] }
+  validates :income_type, presence: true, inclusion: { in: %w[regular loan] }
+  validates :loan_amount, presence: true, numericality: { greater_than: 0 }, if: :loan?
+  validates :number_of_payments, presence: true, numericality: { greater_than: 0, only_integer: true }, if: :loan?
+  validates :payment_frequency, presence: true, inclusion: { in: %w[weekly biweekly quincenal monthly] }, if: :loan?
+  validates :interest_rate, numericality: { greater_than_or_equal_to: 0 }, allow_nil: true
+  validates :payment_amount, numericality: { greater_than: 0 }, allow_nil: true
+  validate :loan_terms_present_for_calculation, if: :loan?
+  validate :loan_payment_amount_consistency, if: :loan?
 
   scope :pending, -> { where(status: "pending") }
   scope :received, -> { where(status: "received") }
@@ -19,6 +34,8 @@ class IncomeEvent < ApplicationRecord
   scope :by_date, -> { order(expected_date: :desc) }
 
   def total_planned
+    return loan_total_planned if loan?
+
     # Include:
     # 1. All planned expenses (they represent planned spending, even if applied)
     # 2. Expenses directly assigned (without a planned_expense_id)
@@ -28,6 +45,8 @@ class IncomeEvent < ApplicationRecord
   end
 
   def total_spent
+    return loan_total_spent if loan?
+
     # Total of all expenses (both from planned and direct)
     expenses.sum(:amount)
   end
@@ -50,6 +69,8 @@ class IncomeEvent < ApplicationRecord
   end
 
   def apply_all!
+    return if loan?
+
     planned_expenses.where.not(status: %w[paid transferred spent]).find_each do |planned_expense|
       planned_expense.apply!
     end
@@ -111,9 +132,150 @@ class IncomeEvent < ApplicationRecord
     remaining_budget + previous_balance
   end
 
+  def loan?
+    income_type == "loan"
+  end
+
+  def regular?
+    !loan?
+  end
+
+  def loan_payment_schedules_ordered
+    loan_payment_schedules.ordered
+  end
+
+  def loan_total_repayment
+    loan_payment_schedules.active.sum(:amount)
+  end
+
+  def loan_total_paid
+    loan_payment_schedules.paid.sum(:amount)
+  end
+
+  def loan_remaining_balance
+    loan_amount.to_d - loan_total_paid.to_d
+  end
+
+  def generate_loan_payment_schedules!(preserve_paid: true)
+    if Rails.env.development?
+      ::Loans.send(:remove_const, :ScheduleGenerator) if defined?(::Loans::ScheduleGenerator)
+      load Rails.root.join("app/services/loans/schedule_generator.rb")
+    elsif !defined?(::Loans::ScheduleGenerator)
+      require Rails.root.join("app/services/loans/schedule_generator")
+    end
+
+    ::Loans::ScheduleGenerator.call(self, preserve_paid: preserve_paid)
+  end
+
+  def inferred_interest_rate?
+    interest_rate_estimated
+  end
+
   private
 
   def set_account
     self.account ||= Current.account if Current.account
+  end
+
+  def normalize_payment_frequency
+    return if payment_frequency.blank?
+
+    self.payment_frequency = "quincenal" if payment_frequency == "quicenal"
+  end
+
+  def apply_loan_defaults
+    self.income_type ||= "regular"
+    return unless loan?
+
+    self.loan_amount ||= expected_amount
+    self.expected_amount = loan_amount if loan_amount.present?
+    self.expected_date ||= Date.current
+    self.received_amount ||= loan_amount if received_amount.blank?
+  end
+
+  def infer_loan_interest_rate
+    return unless loan?
+    if interest_rate.present?
+      self.interest_rate_estimated = false if will_save_change_to_interest_rate?
+      return
+    end
+    return unless payment_amount.present? && number_of_payments.present? && loan_amount.present?
+
+    self.interest_rate = inferred_annual_rate_from_payment
+    self.interest_rate_estimated = true
+  end
+
+  def loan_total_planned
+    loan_payment_schedules.active.sum(:amount)
+  end
+
+  def loan_total_spent
+    loan_payment_schedules.paid.sum(:amount)
+  end
+
+  def refresh_loan_payment_schedules
+    generate_loan_payment_schedules!
+  end
+
+  def loan_terms_present_for_calculation
+    return if interest_rate.present? || payment_amount.present?
+
+    errors.add(:base, "Provide interest rate or payment amount to build the loan schedule")
+  end
+
+  def loan_payment_amount_consistency
+    return unless payment_amount.present? && number_of_payments.present? && loan_amount.present?
+    return unless payment_amount.to_d * number_of_payments.to_i < loan_amount.to_d
+
+    errors.add(:payment_amount, "is too low for the selected number of payments")
+  end
+
+  def inferred_annual_rate_from_payment
+    periods_per_year = {
+      "weekly" => 52.0,
+      "biweekly" => 26.0,
+      "quincenal" => (365.0 / 15.0),
+      "monthly" => 12.0
+    }.fetch(payment_frequency) { 12.0 }
+
+    principal = loan_amount.to_d
+    installment_amount = payment_amount.to_d
+    periods = number_of_payments.to_i
+
+    return 0.to_d if installment_amount * periods <= principal
+
+    periodic_rate = solve_periodic_rate(principal: principal, payment_amount: installment_amount, periods: periods)
+    (periodic_rate * periods_per_year * 100).round(3)
+  end
+
+  def solve_periodic_rate(principal:, payment_amount:, periods:)
+    low = 0.0
+    high = 1.0
+
+    while payment_for_rate(principal: principal, rate: high, periods: periods) < payment_amount
+      high *= 2
+      break if high > 100
+    end
+
+    80.times do
+      mid = (low + high) / 2.0
+      computed_payment = payment_for_rate(principal: principal, rate: mid, periods: periods)
+
+      if computed_payment < payment_amount
+        low = mid
+      else
+        high = mid
+      end
+    end
+
+    ((low + high) / 2.0).to_d
+  end
+
+  def payment_for_rate(principal:, rate:, periods:)
+    return principal / periods if rate.zero?
+
+    numerator = principal * rate
+    denominator = 1 - (1 + rate)**(-periods)
+    numerator / denominator
   end
 end

--- a/app/models/loan_payment_schedule.rb
+++ b/app/models/loan_payment_schedule.rb
@@ -1,0 +1,41 @@
+class LoanPaymentSchedule < ApplicationRecord
+  belongs_to :account
+  belongs_to :loan, class_name: "IncomeEvent"
+
+  before_validation :set_account, on: :create
+
+  scope :for_account, ->(account) { where(account: account) }
+  scope :scheduled, -> { where(status: "scheduled") }
+  scope :paid, -> { where(status: "paid") }
+  scope :overdue, -> { where(status: "overdue") }
+  scope :cancelled, -> { where(status: "cancelled") }
+  scope :active, -> { where.not(status: "cancelled") }
+  scope :ordered, -> { order(:due_date, :installment_number) }
+
+  validates :due_date, presence: true
+  validates :installment_number, presence: true, numericality: { greater_than: 0 }
+  validates :amount, presence: true, numericality: { greater_than: 0 }
+  validates :status, presence: true, inclusion: { in: %w[scheduled paid overdue cancelled] }
+
+  def paid?
+    status == "paid"
+  end
+
+  def scheduled?
+    status == "scheduled"
+  end
+
+  def overdue?
+    status == "overdue"
+  end
+
+  def mark_paid!(paid_at: Date.current)
+    update!(status: "paid", paid_at: paid_at)
+  end
+
+  private
+
+  def set_account
+    self.account ||= Current.account if Current.account
+  end
+end

--- a/app/services/loans/schedule_generator.rb
+++ b/app/services/loans/schedule_generator.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+module Loans
+  class ScheduleGenerator
+    PERIODS_PER_YEAR = {
+      "weekly" => 52.0,
+      "biweekly" => 26.0,
+      "quincenal" => (365.0 / 15.0),
+      "quicenal" => (365.0 / 15.0),
+      "monthly" => 12.0
+    }.freeze
+
+    def self.call(loan, preserve_paid: true)
+      new(loan, preserve_paid:).call
+    end
+
+    def self.annual_rate_from_payment(principal:, payment_amount:, number_of_payments:, payment_frequency:)
+      periods_per_year = PERIODS_PER_YEAR.fetch(payment_frequency) { 12.0 }
+      principal = principal.to_d
+      payment_amount = payment_amount.to_d
+      number_of_payments = number_of_payments.to_i
+
+      return 0.to_d if payment_amount * number_of_payments == principal
+      return 0.to_d if payment_amount * number_of_payments < principal
+
+      periodic_rate = solve_periodic_rate(
+        principal: principal,
+        payment_amount: payment_amount,
+        periods: number_of_payments
+      )
+
+      (periodic_rate * periods_per_year * 100).round(3)
+    end
+
+    def initialize(loan, preserve_paid: true)
+      @loan = loan
+      @preserve_paid = preserve_paid
+    end
+
+    def call
+      return [] unless loan.loan?
+      return [] unless loan.loan_amount.present? && loan.number_of_payments.present? && loan.payment_frequency.present?
+
+      ActiveRecord::Base.transaction do
+        paid_rows = preserve_paid ? loan.loan_payment_schedules.paid.ordered.to_a : []
+        loan.loan_payment_schedules.where.not(id: paid_rows.map(&:id)).delete_all
+
+        generate_rows(paid_rows)
+      end
+    end
+
+    private
+
+    attr_reader :loan, :preserve_paid
+
+    def generate_rows(paid_rows)
+      rows = []
+      start_index = paid_rows.size + 1
+      remaining_principal = [ loan.loan_amount.to_d - paid_rows.sum { |row| row.principal_amount.to_d }, 0 ].max
+      periodic_rate = periodic_interest_rate
+      fixed_payment_mode = loan.payment_amount.present?
+      fixed_payment_amount = loan.payment_amount.to_d.round(2)
+
+      (start_index..loan.number_of_payments).each do |installment_number|
+        break if remaining_principal <= 0 && !fixed_payment_mode
+
+        due_date = due_date_for(installment_number)
+        installments_left = loan.number_of_payments - installment_number + 1
+        interest_amount = (remaining_principal * periodic_rate).round(2)
+
+        principal_amount = if installment_number == loan.number_of_payments
+          remaining_principal
+        elsif fixed_payment_mode
+          calculated_principal = (fixed_payment_amount - interest_amount).round(2)
+          [ calculated_principal, remaining_principal ].min
+        else
+          payment_amount = payment_amount_for(remaining_principal, installments_left)
+          (payment_amount - interest_amount).round(2)
+        end
+        amount = if installment_number == loan.number_of_payments
+          (principal_amount + interest_amount).round(2)
+        elsif fixed_payment_mode
+          fixed_payment_amount
+        else
+          (principal_amount + interest_amount).round(2)
+        end
+
+        rows << loan.loan_payment_schedules.create!(
+          account: loan.account,
+          due_date: due_date,
+          installment_number: installment_number,
+          amount: amount,
+          principal_amount: principal_amount,
+          interest_amount: interest_amount,
+          status: "scheduled"
+        )
+
+        remaining_principal = (remaining_principal - principal_amount).round(2)
+      end
+
+      rows
+    end
+
+    def payment_amount_for(principal, periods)
+      if loan.payment_amount.present?
+        loan.payment_amount.to_d
+      else
+        amortized_payment(principal, periods)
+      end
+    end
+
+    def amortized_payment(principal, periods)
+      rate = periodic_interest_rate
+
+      return (principal / periods).round(2) if rate.zero?
+
+      numerator = principal * rate
+      denominator = 1 - (1 + rate)**(-periods)
+      (numerator / denominator).round(2)
+    end
+
+    def periodic_interest_rate
+      annual_rate = loan.interest_rate.to_d / 100
+      annual_rate / periods_per_year
+    end
+
+    def periods_per_year
+      PERIODS_PER_YEAR.fetch(loan.payment_frequency) { 12.0 }
+    end
+
+    def due_date_for(installment_number)
+      offset = installment_number
+      case loan.payment_frequency
+      when "weekly"
+        loan.expected_date + offset.weeks
+      when "biweekly"
+        loan.expected_date + (offset * 2).weeks
+      when "quincenal", "quicenal"
+        loan.expected_date + (offset * 15).days
+      else
+        loan.expected_date.advance(months: offset)
+      end
+    end
+
+    def self.solve_periodic_rate(principal:, payment_amount:, periods:)
+      low = 0.0
+      high = 1.0
+
+      while payment_for_rate(principal, high, periods) < payment_amount
+        high *= 2
+        break if high > 100
+      end
+
+      80.times do
+        mid = (low + high) / 2.0
+        payment = payment_for_rate(principal, mid, periods)
+
+        if payment < payment_amount
+          low = mid
+        else
+          high = mid
+        end
+      end
+
+      ((low + high) / 2.0).to_d
+    end
+
+    def self.payment_for_rate(principal, rate, periods)
+      return principal / periods if rate.zero?
+
+      numerator = principal * rate
+      denominator = 1 - (1 + rate)**(-periods)
+      numerator / denominator
+    end
+
+    private_class_method :solve_periodic_rate, :payment_for_rate
+  end
+end

--- a/app/views/income_events/_form.html.erb
+++ b/app/views/income_events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: [@budget_period, @income_event].compact, local: true do |form| %>
+<%= form_with model: [@budget_period, @income_event].compact, local: true, data: { controller: "income-event-form", income_event_form_loan_value: @income_event.loan? } do |form| %>
   <% if @income_event.errors.any? %>
     <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@income_event.errors.count, "error") %> prohibited this income event from being saved:</h2>
@@ -16,6 +16,11 @@
   </div>
 
   <div class="mb-4">
+    <%= form.label :income_type, "Income Type", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.select :income_type, [["Regular", "regular"], ["Loan", "loan"]], {}, { class: "border rounded px-3 py-2 w-full", data: { action: "change->income-event-form#toggleLoanFields", income_event_form_target: "incomeTypeSelect" } } %>
+  </div>
+
+  <div class="mb-4">
     <%= form.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= form.text_field :description, class: "border rounded px-3 py-2 w-full" %>
   </div>
@@ -25,9 +30,45 @@
     <%= form.date_field :expected_date, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
-  <div class="mb-4">
+  <div class="mb-4" data-income-event-form-target="expectedAmountField">
     <%= form.label :expected_amount, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= form.number_field :expected_amount, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
+  </div>
+
+  <div class="mb-4 hidden" data-income-event-form-target="loanFields">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div>
+        <%= form.label :loan_amount, "Loan Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.number_field :loan_amount, step: 0.01, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "loanAmountField", action: "input->income-event-form#onSharedTermsChanged" } %>
+      </div>
+      <div>
+        <%= form.label :interest_rate, "Interest Rate (Annual %)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.number_field :interest_rate, step: 0.001, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "interestRateField", action: "input->income-event-form#onInterestInput" } %>
+        <p class="mt-1 text-xs text-gray-500">Use annual nominal rate (APR). Example: 36 means 36% annual.</p>
+        <p class="mt-1 text-xs text-gray-500 hidden" data-income-event-form-target="interestHint"></p>
+      </div>
+      <div>
+        <%= form.label :number_of_payments, "Number of Payments", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.number_field :number_of_payments, min: 1, step: 1, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "numberOfPaymentsField", action: "input->income-event-form#onSharedTermsChanged" } %>
+      </div>
+      <div>
+        <%= form.label :payment_frequency, "Payment Frequency", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.select :payment_frequency, [["Weekly (cada 7 dias)", "weekly"], ["Quincenal (cada 15 dias)", "quincenal"], ["Biweekly / Catorcenal (cada 14 dias)", "biweekly"], ["Monthly", "monthly"]], { include_blank: true }, { class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "paymentFrequencyField", action: "change->income-event-form#onSharedTermsChanged" } } %>
+      </div>
+      <div>
+        <%= form.label :payment_amount, "Payment Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.number_field :payment_amount, step: 0.01, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "paymentAmountField", action: "input->income-event-form#onPaymentInput" } %>
+      </div>
+      <div>
+        <%= form.label :lender_name, "Lender Name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.text_field :lender_name, class: "border rounded px-3 py-2 w-full" %>
+      </div>
+    </div>
+    <div class="mt-4">
+      <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
+    </div>
+    <p class="mt-2 text-xs text-gray-500">For loans, the expected date acts as the loan start date.</p>
   </div>
 
   <div class="mb-4">

--- a/app/views/income_events/_income_event_card.html.erb
+++ b/app/views/income_events/_income_event_card.html.erb
@@ -1,0 +1,147 @@
+<% prev_balance = income_event.previous_balance %>
+<% prev_balance_negative = prev_balance < 0 %>
+<% planning_progress = if income_event.expected_amount.to_f.positive?
+     ((income_event.total_planned / income_event.expected_amount) * 100)
+   else
+     0
+   end %>
+
+<%= render Ui::CardComponent.new(
+  css_class: [
+    "flex h-full flex-col overflow-hidden p-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md",
+    prev_balance_negative ? "border-red-300 shadow-red-100/60" : "border-border/80"
+  ].join(" ")
+) do %>
+  <%= render Ui::CardHeaderComponent.new(css_class: "mb-0 space-y-1 border-b border-border/70 px-4 pt-2 pb-2.5") do %>
+    <div class="flex justify-end leading-none">
+      <span class="inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[9px] leading-none font-medium uppercase tracking-wide <%= 
+        case income_event.status
+        when 'pending' then 'border-yellow-200 bg-yellow-50 text-yellow-800'
+        when 'received' then 'border-blue-200 bg-blue-50 text-blue-800'
+        when 'applied' then 'border-green-200 bg-green-50 text-green-800'
+        else 'border-gray-200 bg-gray-50 text-gray-700'
+        end
+      %>">
+        <%= t("income_events.form.#{income_event.status}") %>
+      </span>
+    </div>
+
+    <%= render Ui::CardTitleComponent.new(css_class: "w-full text-base leading-snug text-foreground sm:text-lg") do %>
+      <%= income_event.description %>
+    <% end %>
+
+    <%= render Ui::CardDescriptionComponent.new(css_class: "flex items-center gap-1.5 text-[13px] leading-snug") do %>
+      <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+      </svg>
+      Expected <span class="font-medium text-foreground"><%= income_event.expected_date.strftime("%b %d, %Y") %></span>
+    <% end %>
+  <% end %>
+
+  <%= render Ui::CardContentComponent.new(css_class: "flex flex-1 flex-col gap-2 px-4 py-3") do %>
+    <div class="space-y-1.5">
+      <div class="flex items-center justify-between gap-3">
+        <span class="text-sm text-muted-foreground">Expected Amount</span>
+        <span class="text-lg font-semibold text-foreground"><%= number_to_currency(income_event.expected_amount) %></span>
+      </div>
+
+      <% if income_event.received_date %>
+        <div class="flex items-center justify-between gap-3 border-t border-border/60 pt-2">
+          <span class="text-sm text-muted-foreground">Received</span>
+          <span class="text-sm font-medium text-green-700">
+            <%= income_event.received_date.strftime("%b %d") %> - <%= number_to_currency(income_event.received_amount) %>
+          </span>
+        </div>
+      <% end %>
+
+      <div class="flex items-center justify-between gap-3 border-t border-border/60 pt-2">
+        <span class="text-sm text-muted-foreground">Planned</span>
+        <span class="text-sm font-medium text-blue-700"><%= number_to_currency(income_event.total_planned) %></span>
+      </div>
+
+      <% if prev_balance != 0 || income_event.previous_income_event %>
+        <div class="border-t border-border/60 pt-2 <%= prev_balance_negative ? 'rounded-md bg-red-50/70 px-3 py-2' : '' %>">
+          <div class="flex items-center justify-between gap-2">
+            <div class="min-w-0">
+              <span class="text-sm text-muted-foreground">Previous Balance</span>
+              <% if income_event.previous_income_event %>
+                <span class="text-xs text-muted-foreground">from <%= income_event.previous_income_event.description %></span>
+              <% end %>
+            </div>
+            <div class="flex items-center gap-1.5">
+              <% if prev_balance_negative %>
+                <svg class="h-4 w-4 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                </svg>
+              <% end %>
+              <span class="text-sm font-semibold <%= prev_balance_negative ? 'text-red-600' : 'text-green-700' %>">
+                <%= number_to_currency(prev_balance) %>
+              </span>
+            </div>
+          </div>
+        </div>
+      <% end %>
+
+      <div class="flex items-center justify-between gap-3 border-t border-border/60 pt-2">
+        <span class="text-sm text-muted-foreground">Remaining</span>
+        <span class="text-sm font-semibold <%= income_event.effective_remaining_budget < 0 ? 'text-red-600' : 'text-green-700' %>">
+          <%= number_to_currency(income_event.effective_remaining_budget) %>
+        </span>
+      </div>
+
+      <% if income_event.expected_amount > 0 %>
+        <div class="border-t border-border/60 pt-2">
+          <div class="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+            <span>Planning Progress</span>
+            <span class="font-semibold text-foreground"><%= planning_progress.round(1) %>%</span>
+          </div>
+          <div class="h-2 w-full rounded-full bg-slate-200">
+            <div class="h-2 rounded-full bg-primary transition-all duration-300" style="width: <%= [planning_progress, 100].min %>%"></div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= render Ui::CardFooterComponent.new(css_class: "mt-auto border-t border-border/70 px-5 py-3") do %>
+    <div class="grid grid-cols-2 gap-2">
+      <%= render Ui::ButtonComponent.new(href: income_event, label: "View", variant: "outline", size: "sm", css_class: "w-full justify-center") do %>
+          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+          </svg>
+      <% end %>
+      <%= render Ui::ButtonComponent.new(href: edit_income_event_path(income_event), label: "Edit", variant: "outline", size: "sm", css_class: "w-full justify-center") %>
+      <% unless income_event.is_received? %>
+        <%= render Ui::ButtonComponent.new(
+          href: receive_income_event_path(income_event),
+          label: "Mark Received",
+          variant: "default",
+          size: "sm",
+          css_class: "w-full justify-center"
+        ) %>
+      <% end %>
+
+      <% if income_event.is_received? && !income_event.is_applied? %>
+        <%= render Ui::ButtonComponent.new(
+          href: apply_all_income_event_path(income_event),
+          label: "Apply All",
+          variant: "default",
+          method: :post,
+          size: "sm",
+          css_class: "w-full justify-center"
+        ) %>
+      <% end %>
+
+      <%= render Ui::ButtonComponent.new(
+        href: income_event,
+        label: "Delete",
+        variant: "destructive",
+        method: :delete,
+        data: { turbo_confirm: "Are you sure? This will delete all associated planned expenses." },
+        size: "sm",
+        css_class: "w-full justify-center"
+      ) %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/income_events/index.html.erb
+++ b/app/views/income_events/index.html.erb
@@ -195,6 +195,9 @@
                 </svg>
               <% end %>
               <%= render Ui::ButtonComponent.new(href: edit_income_event_path(income_event), label: "Edit", variant: "outline", size: "sm", css_class: "w-full sm:w-auto justify-center") %>
+              <% if income_event.loan? %>
+                <%= render Ui::ButtonComponent.new(href: loan_summary_income_event_path(income_event), label: "Loan Summary", variant: "outline", size: "sm", css_class: "w-full sm:w-auto justify-center") %>
+              <% end %>
             </div>
             <div class="flex flex-col gap-2 w-full sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">
               <% unless income_event.is_received? %>

--- a/app/views/income_events/loan_summary.html.erb
+++ b/app/views/income_events/loan_summary.html.erb
@@ -1,0 +1,104 @@
+<p style="color: green"><%= notice %></p>
+
+<div class="mb-6">
+  <%= link_to @income_event, class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+    <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+    </svg>
+    Back to Loan
+  <% end %>
+</div>
+
+<div class="bg-gradient-to-r from-slate-900 to-slate-700 rounded-2xl shadow-xl p-8 mb-8 text-white">
+  <div class="flex items-start justify-between gap-6 flex-wrap">
+    <div>
+      <h1 class="text-3xl font-bold mb-2"><%= @income_event.description %></h1>
+      <p class="text-slate-200">Loan summary and repayment checklist</p>
+    </div>
+    <div class="text-right">
+      <p class="text-slate-300 text-sm">Start date</p>
+      <p class="text-lg font-semibold"><%= @income_event.expected_date.strftime("%B %d, %Y") %></p>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mt-8">
+    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
+      <p class="text-slate-300 text-sm">Loan amount</p>
+      <p class="text-2xl font-bold"><%= number_to_currency(@income_event.loan_amount || @income_event.expected_amount) %></p>
+    </div>
+    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
+      <p class="text-slate-300 text-sm">Interest rate</p>
+      <p class="text-2xl font-bold"><%= number_with_precision(@income_event.interest_rate || 0, precision: 3) %>%</p>
+      <p class="text-xs text-slate-300 mt-1"><%= @income_event.inferred_interest_rate? ? "Estimated from payment amount" : "Provided by user" %></p>
+    </div>
+    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
+      <p class="text-slate-300 text-sm">Total repayable</p>
+      <p class="text-2xl font-bold"><%= number_to_currency(@income_event.loan_total_repayment) %></p>
+    </div>
+    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
+      <p class="text-slate-300 text-sm">Remaining balance</p>
+      <p class="text-2xl font-bold"><%= number_to_currency(@income_event.loan_remaining_balance) %></p>
+    </div>
+    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
+      <p class="text-slate-300 text-sm">Payments</p>
+      <p class="text-2xl font-bold"><%= @loan_payment_schedules.count %></p>
+    </div>
+  </div>
+</div>
+
+<div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mb-8">
+  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+    <h2 class="text-xl font-semibold text-gray-900 mb-4">Payment schedule</h2>
+    <% if @loan_payment_schedules.any? %>
+      <div class="space-y-3">
+        <% @loan_payment_schedules.each do |schedule| %>
+          <div class="flex items-center justify-between rounded-lg border border-gray-200 p-4 <%= schedule.paid? ? 'bg-green-50' : 'bg-white' %>">
+            <div>
+              <p class="font-medium text-gray-900">Payment <%= schedule.installment_number %></p>
+              <p class="text-sm text-gray-600"><%= schedule.due_date.strftime("%b %d, %Y") %></p>
+            </div>
+            <div class="text-right">
+              <p class="font-semibold text-gray-900"><%= number_to_currency(schedule.amount) %></p>
+              <p class="text-xs text-gray-500"><%= schedule.status %></p>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-gray-600">No payment schedule has been generated yet.</p>
+    <% end %>
+  </div>
+
+  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+    <h2 class="text-xl font-semibold text-gray-900 mb-4">Checklist</h2>
+    <p class="text-sm text-gray-600 mb-4">Planned expenses and loan payments together for execution.</p>
+
+    <% if @planned_expenses.any? %>
+      <div class="mb-6">
+        <h3 class="text-sm font-semibold text-gray-700 mb-2">Planned expenses</h3>
+        <div class="space-y-2">
+          <% @planned_expenses.each do |planned_expense| %>
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+              <span class="text-sm text-gray-900"><%= planned_expense.description %></span>
+              <span class="text-sm font-medium text-gray-700"><%= number_to_currency(planned_expense.amount) %></span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+
+    <% if @loan_payment_schedules.any? %>
+      <div>
+        <h3 class="text-sm font-semibold text-gray-700 mb-2">Loan payments</h3>
+        <div class="space-y-2">
+          <% @loan_payment_schedules.each do |schedule| %>
+            <div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
+              <span class="text-sm text-gray-900">Payment <%= schedule.installment_number %></span>
+              <span class="text-sm font-medium text-gray-700"><%= number_to_currency(schedule.amount) %></span>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/income_events/show.html.erb
+++ b/app/views/income_events/show.html.erb
@@ -120,6 +120,14 @@
 <!-- Action Buttons -->
 <div class="flex flex-wrap gap-3 mb-8">
   <%= render Ui::ButtonComponent.new(href: edit_income_event_path(@income_event), label: "Edit", variant: "outline", size: "lg") %>
+  <% if @income_event.loan? %>
+    <%= render Ui::ButtonComponent.new(
+      href: loan_summary_income_event_path(@income_event),
+      label: "Loan Summary",
+      variant: "default",
+      size: "lg"
+    ) %>
+  <% end %>
   <% unless @income_event.is_received? %>
     <%= render Ui::ButtonComponent.new(
       href: receive_income_event_path(@income_event),
@@ -220,6 +228,65 @@
           variant: "default"
         ) %>
       </div>
+    </div>
+  <% end %>
+</div>
+
+<!-- Pending Liability Payments Section -->
+<div class="mb-6">
+  <div class="flex items-center justify-between mb-4">
+    <h2 class="text-2xl font-bold text-gray-900">Pending Liability Payments</h2>
+    <p class="text-sm text-gray-600">Apply payments from this income event to reduce debt balances.</p>
+  </div>
+
+  <% if @pending_liabilities.any? %>
+    <div class="space-y-4">
+      <% @pending_liabilities.each do |liability| %>
+        <div class="bg-white rounded-lg border border-gray-200 p-4">
+          <div class="flex flex-wrap items-center justify-between gap-3 mb-3">
+            <div>
+              <h3 class="font-semibold text-gray-900"><%= liability.name %></h3>
+              <p class="text-sm text-gray-600"><%= liability.liability_type.humanize %></p>
+            </div>
+            <div class="text-right">
+              <p class="text-xs text-gray-500">Current owed</p>
+              <p class="text-lg font-bold text-red-600"><%= number_to_currency(liability.current_balance) %></p>
+            </div>
+          </div>
+
+          <%= form_with url: pay_liability_income_event_path(@income_event), method: :post, local: true, class: "grid grid-cols-1 md:grid-cols-5 gap-3" do %>
+            <%= hidden_field_tag "income_event_liability_payment[financial_liability_id]", liability.id %>
+
+            <div class="md:col-span-2">
+              <%= label_tag "income_event_liability_payment_financial_account_id_#{liability.id}", "Pay from account", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= select_tag "income_event_liability_payment[financial_account_id]", options_from_collection_for_select(@active_financial_accounts, :id, :name), include_blank: "Select account", class: "border rounded px-3 py-2 w-full", required: true, id: "income_event_liability_payment_financial_account_id_#{liability.id}" %>
+            </div>
+
+            <div>
+              <%= label_tag "income_event_liability_payment_amount_#{liability.id}", "Amount", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= number_field_tag "income_event_liability_payment[amount]", liability.current_balance, step: 0.01, min: 0.01, max: liability.current_balance, class: "border rounded px-3 py-2 w-full", required: true, id: "income_event_liability_payment_amount_#{liability.id}" %>
+            </div>
+
+            <div>
+              <%= label_tag "income_event_liability_payment_entry_date_#{liability.id}", "Date", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= date_field_tag "income_event_liability_payment[entry_date]", Date.current, class: "border rounded px-3 py-2 w-full", required: true, id: "income_event_liability_payment_entry_date_#{liability.id}" %>
+            </div>
+
+            <div>
+              <%= label_tag "income_event_liability_payment_description_#{liability.id}", "Description", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= text_field_tag "income_event_liability_payment[description]", "Payment to #{liability.name}", class: "border rounded px-3 py-2 w-full", id: "income_event_liability_payment_description_#{liability.id}" %>
+            </div>
+
+            <div class="md:col-span-5 flex justify-end">
+              <%= submit_tag "Apply payment", class: "px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700", data: { turbo_confirm: "Apply payment to #{liability.name}? Please verify source account and amount before continuing." } %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  <% else %>
+    <div class="text-center py-8 bg-white rounded-xl border-2 border-dashed border-gray-300">
+      <p class="text-sm text-gray-500">No pending liabilities with outstanding balances.</p>
     </div>
   <% end %>
 </div>

--- a/app/views/planned_expenses/show.html.erb
+++ b/app/views/planned_expenses/show.html.erb
@@ -80,10 +80,21 @@
         href: apply_income_event_planned_expense_path(@income_event, @planned_expense),
         label: "Apply",
         variant: "default",
-        data: { turbo_method: :patch }
+        data: {
+          turbo_method: :patch,
+          turbo_confirm: "Apply this planned expense now? This will create an expense record for #{number_to_currency(@planned_expense.amount)}."
+        }
       ) %>
     <% end %>
-    <%= render Ui::ButtonComponent.new(href: [@income_event, @planned_expense], label: "Delete", variant: "destructive", method: :delete) %>
+    <%= render Ui::ButtonComponent.new(
+      href: [@income_event, @planned_expense],
+      label: "Delete",
+      variant: "destructive",
+      method: :delete,
+      data: {
+        turbo_confirm: "Delete this planned expense? This action cannot be undone."
+      }
+    ) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,9 +46,11 @@ Rails.application.routes.draw do
       end
     end
     member do
+      get :loan_summary
       get :receive
       patch :receive
       post :apply_all
+      post :pay_liability
     end
   end
 


### PR DESCRIPTION
# feat: add loan planning flow and liability payments to income events

## Summary
Add loan-specific behavior to income events, including loan term capture, repayment schedule generation,
a dedicated loan summary view, and the ability to apply income event funds toward pending liabilities.
This also improves related UI flows with confirmations and richer income event cards. :contentReference[oaicite:0]{index=0}

## Changes
- Add loan support to `IncomeEvent`, including new fields/validations, inferred interest rate calculation, payment consistency checks, and automatic loan schedule refresh.
- Introduce `LoanPaymentSchedule` plus `Loans::ScheduleGenerator` to build and preserve repayment schedules, including support for multiple payment frequencies.
- Extend `IncomeEventsController` with `loan_summary` and `pay_liability`, and load loan schedules, active financial accounts, and pending liabilities in the show flow.
- Add Stimulus-driven loan form behavior to toggle loan fields and keep payment amount / annual interest rate in sync based on user input.
- Add loan-focused UI in income event form, show page, index page, and a dedicated `loan_summary` page for repayment overview and checklist execution.
- Add pending liability payment forms to income event details so users can pay active liabilities directly from an income event.
- Improve UX with confirmation prompts for applying and deleting planned expenses, plus a richer income event card presentation.

## Testing
- Not provided (please add).
- Create a regular income event and verify existing non-loan behavior still works unchanged.
- Create a loan income event with interest rate provided and verify repayment schedules are generated correctly.
- Create a loan income event with payment amount only and verify annual interest is inferred consistently in both form JS and model logic.
- Edit a loan after some payments are marked paid and verify schedule regeneration preserves paid rows as intended.
- Open the loan summary page and verify totals, repayment rows, and checklist data render correctly.
- Apply a pending liability payment from an income event and verify balances, source account handling, and success/error flows.
- Confirm destructive/apply actions now show the expected Turbo confirmation dialogs.

## Notes / Risks
- Diff appears partial; verify routes, migrations/schema changes, and authorization coverage for `loan_summary` and `pay_liability`.
- Interest-rate inference exists in both Stimulus and Ruby code; validate parity carefully to avoid mismatched calculations between UI and persisted records.
- `after_save :refresh_loan_payment_schedules, if: :loan?` may regenerate schedules frequently, so verify update flows do not create unintended churn or performance issues.