### PR TITLE
Implement expenses form with account type selection and persistence

### DIFF
--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -79,10 +79,17 @@ class ExpensesController < ApplicationController
     @expense.income_event = @income_event
     @expense.budget_period ||= @income_event.budget_period
 
-    if @expense.save
+    result = Expenses::RecordExecutionService.call(
+      expense: @expense,
+      financial_account_id: quick_expense_params[:financial_account_id],
+      financial_liability_id: quick_expense_params[:financial_liability_id]
+    )
+
+    if result.success?
       redirect_to @income_event, notice: t("expenses.flash.quick_created")
     else
       load_quick_form_collections
+      flash.now[:alert] = result.error_message
       render :quick_new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -2,6 +2,7 @@ class ExpensesController < ApplicationController
   before_action :set_budget_period, only: [ :new, :create ]
   before_action :set_income_event_context, only: [ :quick_new, :quick_create ]
   before_action :set_expense, only: %i[ show edit update destroy ]
+  before_action :load_finance_account_collections, only: [ :new, :create, :edit, :update, :quick_new, :quick_create ]
 
 
   def index
@@ -146,5 +147,10 @@ class ExpensesController < ApplicationController
     def load_quick_form_collections
       @categories = Category.for_account(Current.account).order(:name)
       @budget_periods = BudgetPeriod.for_account(Current.account).order(start_date: :desc)
+    end
+
+    def load_finance_account_collections
+      @financial_accounts = Financial::Asset.for_account(Current.account).active.order(:name)
+      @financial_liabilities = Financial::Liability.for_account(Current.account).active.order(:name)
     end
 end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -53,7 +53,13 @@ class ExpensesController < ApplicationController
     end
 
     respond_to do |format|
-      if @expense.save
+      result = Expenses::RecordExecutionService.call(
+        expense: @expense,
+        financial_account_id: expense_params[:financial_account_id],
+        financial_liability_id: expense_params[:financial_liability_id]
+      )
+
+      if result.success?
         target = @expense.budget_period || @expense
         format.html { redirect_to target, notice: t("expenses.flash.created") }
         format.json { render :show, status: :created, location: @expense }

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -140,7 +140,7 @@ class ExpensesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def expense_params
-      params.expect(expense: [ :date, :amount, :description, :category_id, :budget_period_id, :income_event_id ])
+      params.expect(expense: [ :date, :amount, :description, :category_id, :budget_period_id, :income_event_id, :financial_account_id, :financial_liability_id ])
     end
 
     def set_budget_period
@@ -154,7 +154,7 @@ class ExpensesController < ApplicationController
     end
 
     def quick_expense_params
-      params.expect(expense: [ :date, :amount, :description, :category_id, :budget_period_id ])
+      params.expect(expense: [ :date, :amount, :description, :category_id, :budget_period_id, :financial_account_id, :financial_liability_id ])
     end
 
     def load_quick_form_collections

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -48,7 +48,7 @@ class ExpensesController < ApplicationController
 
     # Auto-suggest budget_period from income_event if income_event is set and budget_period is not
     if @expense.income_event_id.present? && @expense.budget_period_id.blank?
-      income_event = IncomeEvent.find(@expense.income_event_id)
+      income_event = IncomeEvent.for_account(Current.account).find(@expense.income_event_id)
       @expense.budget_period_id = income_event.budget_period_id if income_event.budget_period_id
     end
 
@@ -66,6 +66,7 @@ class ExpensesController < ApplicationController
       else
         # Load income events for form re-render on error
         @income_events = IncomeEvent.for_account(Current.account).order(expected_date: :desc)
+        flash.now[:alert] = result.error_message
         format.html { render :new, status: :unprocessable_entity }
         format.json { render json: @expense.errors, status: :unprocessable_entity }
       end
@@ -116,6 +117,7 @@ class ExpensesController < ApplicationController
       else
         # Load income events for form re-render on error
         @income_events = IncomeEvent.for_account(Current.account).order(expected_date: :desc)
+        load_finance_account_collections
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @expense.errors, status: :unprocessable_entity }
       end

--- a/app/javascript/controllers/expense_form_controller.js
+++ b/app/javascript/controllers/expense_form_controller.js
@@ -1,7 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["dateField", "incomeEventSelect", "incomeEventContainer", "message"]
+  static targets = [
+    "dateField",
+    "incomeEventSelect",
+    "incomeEventContainer",
+    "message",
+    "accountTypeSelect",
+    "assetAccountSection",
+    "liabilityAccountSection"
+  ]
   static values = {
     incomeEvents: Array,
     locale: String
@@ -18,6 +26,8 @@ export default class extends Controller {
       // Show all income events initially
       this.updateIncomeEventOptions(this.allIncomeEvents)
     }
+
+    this.toggleFinanceAccountFields()
   }
 
   filterByDate() {
@@ -207,5 +217,29 @@ export default class extends Controller {
     if (!this.hasMessageTarget) return
 
     this.messageTarget.classList.add('hidden')
+  }
+
+  toggleFinanceAccountFields() {
+    if (!this.hasAccountTypeSelectTarget) return
+
+    const accountType = this.accountTypeSelectTarget.value || 'asset'
+    const showAsset = accountType === 'asset'
+    const showLiability = accountType === 'liability'
+
+    if (this.hasAssetAccountSectionTarget) {
+      this.assetAccountSectionTarget.classList.toggle('hidden', !showAsset)
+    }
+
+    if (this.hasLiabilityAccountSectionTarget) {
+      this.liabilityAccountSectionTarget.classList.toggle('hidden', !showLiability)
+    }
+
+    if (showAsset && this.element.querySelector("#expense_financial_liability_id")) {
+      this.element.querySelector("#expense_financial_liability_id").value = ""
+    }
+
+    if (showLiability && this.element.querySelector("#expense_financial_account_id")) {
+      this.element.querySelector("#expense_financial_account_id").value = ""
+    }
   }
 }

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -4,7 +4,7 @@ class Expense < ApplicationRecord
   belongs_to :budget_period
   belongs_to :income_event, optional: true
   belongs_to :loan, class_name: "IncomeEvent", optional: true
-  belongs_to :financial_account, class_name: "Financial::Account", optional: true
+  belongs_to :financial_account, class_name: "Financial::Asset", optional: true
   belongs_to :financial_liability, class_name: "Financial::Liability", optional: true
   belongs_to :planned_expense, optional: true
   has_one :shopping_item, dependent: :nullify

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -52,6 +52,31 @@
       </div>
     </div>
 
+    <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div>
+        <%= form.label :account_type, "Account Type", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= select_tag :account_type,
+              options_for_select([["Asset account", "asset"], ["Liability account", "liability"]], @expense.financial_liability_id.present? ? "liability" : "asset"),
+              class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500",
+              data: { expense_form_target: "accountTypeSelect", action: "change->expense-form#toggleFinanceAccountFields" } %>
+        <p class="mt-1 text-xs text-gray-500">Choose where this expense is being charged from.</p>
+      </div>
+    </div>
+
+    <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div data-expense-form-target="assetAccountSection" class="space-y-2">
+        <%= form.label :financial_account_id, "Asset account", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.collection_select :financial_account_id, @financial_accounts, :id, lambda { |fa| "#{fa.name} (#{fa.account_type.humanize})" }, { include_blank: "Select asset account" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
+        <p class="mt-1 text-xs text-gray-500">Use for debit/checking/savings payments.</p>
+      </div>
+
+      <div data-expense-form-target="liabilityAccountSection" class="space-y-2 hidden">
+        <%= form.label :financial_liability_id, "Liability account", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.collection_select :financial_liability_id, @financial_liabilities, :id, lambda { |fl| "#{fl.name} (#{fl.liability_type.humanize})" }, { include_blank: "Select liability account" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
+        <p class="mt-1 text-xs text-gray-500">Use for credit cards and personal credit / loan accounts.</p>
+      </div>
+    </div>
+
     <!-- Income Event (Third) - Filtered by Date -->
     <div class="mt-6" data-expense-form-target="incomeEventContainer">
       <%= form.label :income_event_id, "Evento de ingreso", class: "block text-sm font-medium text-gray-700 mb-2" %>


### PR DESCRIPTION
## Summary

Enhances the expense workflow to support payments from both asset and liability accounts, with dynamic form behavior and automatic financial entry creation through service execution.

## Changes Included

### Expense Creation Flow

* Integrated `Expenses::RecordExecutionService` into:

  * `create`
  * `quick_create`
* Persists expense records and related financial entries in a single flow.
* Redirects users to the appropriate target after successful creation.

### Controller Updates

* Added loading of available asset and liability accounts for:

  * `new`
  * `create`
  * `edit`
  * `update`
  * `quick_new`
  * `quick_create`
* Extended strong params to allow:

  * `financial_account_id`
  * `financial_liability_id`
* Improved error handling with flash alerts and proper form reload data.

### Expense Form UI

* Added account type selector:

  * Asset account
  * Liability account
* Added dedicated selectors for:

  * Asset accounts
  * Liability accounts
* Improved guidance text for payment source selection.

### Stimulus Enhancements

* Added dynamic toggling between asset/liability sections.
* Clears hidden field values when switching account type.
* Initializes correct state on page load.

### Model Updates

* Updated `Expense#financial_account` association to use `Financial::Asset`.
* Maintained optional liability relationship through `financial_liability`.

## Impact

Users can now register expenses paid from debit/checking accounts or charged to credit/liability accounts, improving real-world expense tracking and ledger accuracy.

## Notes

This lays the foundation for more advanced payment flows such as transfers, installments, and automatic reconciliation.
