### PR TITLE
Fix move planned expense

### DIFF
--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -69,6 +69,15 @@ class PlannedExpensesController < ApplicationController
         format.json { render json: @planned_expense.errors, status: :unprocessable_entity }
       end
     end
+  rescue ActiveRecord::RecordInvalid => e
+    @planned_expense.errors.add(:base, e.record.errors.full_messages.to_sentence)
+    @expense_templates = ExpenseTemplate.for_account(Current.account).includes(:category).all
+    @income_events = ordered_income_events_for_reference(@planned_expense.due_date)
+    load_route_collections
+    respond_to do |format|
+      format.html { render :edit, status: :unprocessable_entity }
+      format.json { render json: @planned_expense.errors, status: :unprocessable_entity }
+    end
   end
 
   def destroy

--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -54,11 +54,8 @@ class PlannedExpensesController < ApplicationController
       if @planned_expense.update(planned_expense_params)
         # If income_event_id changed, redirect to the new income event
         if new_income_event_id.present? && new_income_event_id.to_i != old_income_event.id
-          new_income_event = IncomeEvent.find(new_income_event_id)
-          # Update position if moving to a new income event
-          if @planned_expense.position.nil?
-            @planned_expense.update(position: (new_income_event.planned_expenses.maximum(:position) || 0) + 1)
-          end
+          new_income_event = IncomeEvent.for_account(Current.account).find(new_income_event_id)
+          move_planned_expense_to!(@planned_expense, new_income_event)
           format.html { redirect_to income_event_planned_expenses_path(new_income_event), notice: "Planned expense was successfully moved and updated." }
         else
           format.html { redirect_to income_event_planned_expenses_path(@income_event), notice: t("planned_expenses.flash.updated") }

--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -114,15 +114,13 @@ class PlannedExpensesController < ApplicationController
       return
     end
 
-    old_income_event = @income_event
-    @planned_expense.update(income_event_id: target_income_event.id)
-
-    # Update position if needed
-    if @planned_expense.position.nil?
-      @planned_expense.update(position: (target_income_event.planned_expenses.maximum(:position) || 0) + 1)
+    ActiveRecord::Base.transaction do
+      move_planned_expense_to!(@planned_expense, target_income_event)
     end
 
     redirect_to income_event_planned_expenses_path(target_income_event), notice: t("planned_expenses.flash.moved_to", description: target_income_event.description)
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to income_event_planned_expenses_path(@income_event), alert: e.record.errors.full_messages.to_sentence
   end
 
   private

--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -159,4 +159,23 @@ class PlannedExpensesController < ApplicationController
     prioritized_same_month = on_or_before.sort_by(&:expected_date).reverse + after.sort_by(&:expected_date)
     prioritized_same_month + others.sort_by(&:expected_date).reverse
   end
+
+  def move_planned_expense_to!(planned_expense, target_income_event)
+    planned_expense.update!(income_event_id: target_income_event.id)
+
+    if planned_expense.position.nil?
+      planned_expense.update!(position: (target_income_event.planned_expenses.maximum(:position) || 0) + 1)
+    end
+
+    if planned_expense.expense.present?
+      planned_expense.expense.update!(
+        income_event_id: target_income_event.id,
+        budget_period_id: target_income_event.budget_period_id
+      )
+    end
+
+    return unless planned_expense.financial_entry.present?
+
+    planned_expense.financial_entry.update!(income_event_id: target_income_event.id)
+  end
 end

--- a/test/controllers/planned_expenses_controller_test.rb
+++ b/test/controllers/planned_expenses_controller_test.rb
@@ -170,4 +170,49 @@ class PlannedExpensesControllerTest < ActionDispatch::IntegrationTest
     assert_select "form[data-template-selector-edit-mode-value='true']", 1,
       "Edit form should have edit mode so amount is preserved"
   end
+
+  test "move keeps linked spent expense in sync with new income event" do
+    sign_in
+
+    target_income_event = income_events(:two)
+    budget_period = BudgetPeriod.create!(
+      name: "Move Regression Period",
+      start_date: Date.current.beginning_of_month,
+      end_date: Date.current.end_of_month,
+      account: @account
+    )
+    @income_event.update!(budget_period: budget_period)
+    target_income_event.update!(budget_period: budget_period)
+
+    planned_expense = PlannedExpense.create!(
+      income_event: @income_event,
+      category: @category,
+      account: @account,
+      description: "Regression spent planned expense",
+      amount: 60.00,
+      status: "pending_to_pay",
+      financial_account: @source_account
+    )
+
+    expense = Expense.create!(
+      date: Date.current,
+      amount: planned_expense.amount,
+      description: planned_expense.description,
+      category: @category,
+      budget_period: budget_period,
+      income_event: @income_event,
+      account: @account,
+      planned_expense: planned_expense,
+      financial_account: @source_account
+    )
+
+    patch move_income_event_planned_expense_path(@income_event, planned_expense), params: {
+      target_income_event_id: target_income_event.id
+    }
+
+    assert_redirected_to income_event_planned_expenses_path(target_income_event)
+    assert_equal target_income_event.id, planned_expense.reload.income_event_id
+    assert_equal target_income_event.id, expense.reload.income_event_id
+    assert_equal target_income_event.budget_period_id, expense.budget_period_id
+  end
 end


### PR DESCRIPTION
## Summary

This PR improves the planned expense move flow by keeping related records in sync when a planned expense is moved to another income event.

## Changes

- Added a shared `move_planned_expense_to!` controller method to centralize the move logic.
- Ensured moved planned expenses are scoped to the current account when selecting the target income event.
- Updated linked spent `Expense` records when their planned expense moves to a new income event.
- Synced the linked expense’s `budget_period_id` with the target income event’s budget period.
- Updated linked `Financial::Entry` records to reference the new income event.
- Wrapped the move action in a transaction to avoid partial updates.
- Added error handling for invalid move operations.
- Added a regression test to verify that linked spent expenses stay in sync after moving a planned expense.

## Why

Before this change, moving a planned expense could update the planned expense but leave its linked spent expense pointing to the old income event. This created inconsistent reporting and budget-period data.

This PR makes the move operation safer and keeps the planned expense, linked expense, and financial entry aligned.