### PR TITLE
Handle planned expense move installment conflicts gracefully

### DIFF
--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -121,6 +121,8 @@ class PlannedExpensesController < ApplicationController
     redirect_to income_event_planned_expenses_path(target_income_event), notice: t("planned_expenses.flash.moved_to", description: target_income_event.description)
   rescue ActiveRecord::RecordInvalid => e
     redirect_to income_event_planned_expenses_path(@income_event), alert: e.record.errors.full_messages.to_sentence
+  rescue ActiveRecord::RecordNotUnique
+    redirect_to income_event_planned_expenses_path(@income_event), alert: move_conflict_message(target_income_event)
   end
 
   private
@@ -168,6 +170,8 @@ class PlannedExpensesController < ApplicationController
   end
 
   def move_planned_expense_to!(planned_expense, target_income_event)
+    ensure_unique_installment_for!(planned_expense, target_income_event)
+
     planned_expense.update!(income_event_id: target_income_event.id)
 
     if planned_expense.position.nil?
@@ -185,4 +189,23 @@ class PlannedExpensesController < ApplicationController
 
     planned_expense.financial_entry.update!(income_event_id: target_income_event.id)
   end
+
+  def ensure_unique_installment_for!(planned_expense, target_income_event)
+    return if planned_expense.loan_installment_number.blank?
+
+    conflict_exists = target_income_event.planned_expenses
+      .where(loan_installment_number: planned_expense.loan_installment_number)
+      .where.not(id: planned_expense.id)
+      .exists?
+
+    return unless conflict_exists
+
+    planned_expense.errors.add(:loan_installment_number, :taken, message: move_conflict_message(target_income_event))
+    raise ActiveRecord::RecordInvalid.new(planned_expense)
+  end
+
+  def move_conflict_message(target_income_event)
+    "Cannot move this planned expense because installment ##{@planned_expense.loan_installment_number} already exists in #{target_income_event.description}."
+  end
+
 end

--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -207,5 +207,4 @@ class PlannedExpensesController < ApplicationController
   def move_conflict_message(target_income_event)
     "Cannot move this planned expense because installment ##{@planned_expense.loan_installment_number} already exists in #{target_income_event.description}."
   end
-
 end


### PR DESCRIPTION
### Motivation
- Prevent a 500 error when moving a `PlannedExpense` that would violate the unique index on `(income_event_id, loan_installment_number)` by providing a user-facing validation instead of letting the DB constraint surface as an unhandled exception. 
- Provide a clear message to the user explaining why the move cannot proceed when the same `loan_installment_number` already exists in the target `IncomeEvent`.
- Add a defensive fallback to handle potential race conditions where a conflicting record could be created concurrently.

### Description
- Added a pre-move check `ensure_unique_installment_for!` that raises `ActiveRecord::RecordInvalid` with a user-facing message when the target `IncomeEvent` already contains the same `loan_installment_number` for a different `PlannedExpense`.
- Call `ensure_unique_installment_for!` from `move_planned_expense_to!` before updating `income_event_id` to avoid triggering the database unique index violation.
- Added `move_conflict_message` to centralize the conflict message and used it both for validation and the fallback.
- Rescued `ActiveRecord::RecordNotUnique` in `move` to catch race conditions and return a friendly alert instead of raising a 500.

### Testing
- Ran a syntax check with `bundle exec ruby -c app/controllers/planned_expenses_controller.rb`, which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd3921f83c8332a23cc3dcca5e1d4a)