### PR TITLE
Add origin_income_event to PlannedExpense; preserve installment uniqueness and adjust move logic

### DIFF
--- a/app/controllers/income_events_controller.rb
+++ b/app/controllers/income_events_controller.rb
@@ -32,7 +32,9 @@ class IncomeEventsController < ApplicationController
   end
 
   def show
-    @planned_expenses = @income_event.planned_expenses_ordered
+    @planned_expenses = @income_event.originated_planned_expenses
+      .includes(:income_event)
+      .order(Arel.sql("COALESCE(planned_expenses.loan_installment_number, 2147483647) ASC"), :due_date, :created_at)
     @direct_expenses = @income_event.expenses.where(planned_expense_id: nil).order(date: :desc)
     @loan_payment_schedules = @income_event.loan_payment_schedules_ordered if @income_event.loan?
     @pending_liabilities = Financial::Liability.for_account(Current.account).active.select { |liability| liability.current_balance.positive? }
@@ -41,7 +43,9 @@ class IncomeEventsController < ApplicationController
 
   def loan_summary
     @loan_payment_schedules = @income_event.loan_payment_schedules_ordered
-    @planned_expenses = @income_event.planned_expenses_ordered
+    @planned_expenses = @income_event.originated_planned_expenses
+      .includes(:income_event)
+      .order(Arel.sql("COALESCE(planned_expenses.loan_installment_number, 2147483647) ASC"), :due_date, :created_at)
     @direct_expenses = @income_event.expenses.where(planned_expense_id: nil).order(date: :desc)
   end
 

--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -192,6 +192,7 @@ class PlannedExpensesController < ApplicationController
 
   def ensure_unique_installment_for!(planned_expense, target_income_event)
     return if planned_expense.loan_installment_number.blank?
+    return if planned_expense.origin_income_event_id.present?
 
     conflict_exists = target_income_event.planned_expenses
       .where(loan_installment_number: planned_expense.loan_installment_number)

--- a/app/models/income_event.rb
+++ b/app/models/income_event.rb
@@ -9,6 +9,7 @@ class IncomeEvent < ApplicationRecord
   belongs_to :regular_income_destination_asset, class_name: "Financial::Asset", optional: true
   belongs_to :regular_income_destination_liability, class_name: "Financial::Liability", optional: true
   has_many :planned_expenses, dependent: :destroy
+  has_many :originated_planned_expenses, class_name: "PlannedExpense", foreign_key: :origin_income_event_id, dependent: :nullify
   has_many :expenses, dependent: :nullify
   has_many :loan_payment_schedules, foreign_key: :loan_id, dependent: :destroy
   has_one :loan_disbursement_entry, -> { where(entry_type: "loan_disbursement") }, class_name: "Financial::Entry", inverse_of: :income_event

--- a/app/models/planned_expense.rb
+++ b/app/models/planned_expense.rb
@@ -3,6 +3,7 @@ class PlannedExpense < ApplicationRecord
 
   belongs_to :account
   belongs_to :income_event
+  belongs_to :origin_income_event, class_name: "IncomeEvent", optional: true
   belongs_to :category
   belongs_to :expense_template, optional: true
   belongs_to :shopping_item, optional: true

--- a/app/services/loans/planned_expense_sync_service.rb
+++ b/app/services/loans/planned_expense_sync_service.rb
@@ -45,6 +45,7 @@ module Loans
       planned.description = "Loan payment ##{schedule.installment_number} - #{loan.description}" if planned.description.blank?
       planned.amount = schedule.amount
       planned.notes ||= "Auto-generated from loan schedule"
+      planned.origin_income_event = loan
       planned.due_date = schedule.due_date
       planned.status ||= "pending_to_pay"
 

--- a/app/views/income_events/loan_summary.html.erb
+++ b/app/views/income_events/loan_summary.html.erb
@@ -78,9 +78,19 @@
         <h3 class="text-sm font-semibold text-gray-700 mb-2">Planned expenses</h3>
         <div class="space-y-2">
           <% @planned_expenses.each do |planned_expense| %>
-            <div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
-              <span class="text-sm text-gray-900"><%= planned_expense.description %></span>
-              <span class="text-sm font-medium text-gray-700"><%= number_to_currency(planned_expense.amount) %></span>
+            <div class="rounded-lg border border-gray-200 px-4 py-3">
+              <div class="flex items-center justify-between gap-3">
+                <span class="text-sm text-gray-900"><%= planned_expense.description %></span>
+                <span class="text-sm font-medium text-gray-700"><%= number_to_currency(planned_expense.amount) %></span>
+              </div>
+              <p class="mt-1 text-xs text-gray-500">
+                Pays from:
+                <% if planned_expense.income_event_id == @income_event.id %>
+                  this loan event
+                <% else %>
+                  <%= planned_expense.income_event.description %>
+                <% end %>
+              </p>
             </div>
           <% end %>
         </div>

--- a/app/views/income_events/loan_summary.html.erb
+++ b/app/views/income_events/loan_summary.html.erb
@@ -80,7 +80,9 @@
           <% @planned_expenses.each do |planned_expense| %>
             <div class="rounded-lg border border-gray-200 px-4 py-3">
               <div class="flex items-center justify-between gap-3">
-                <span class="text-sm text-gray-900"><%= planned_expense.description %></span>
+                <%= link_to [planned_expense.income_event, planned_expense], class: "text-sm text-blue-700 hover:text-blue-900 hover:underline" do %>
+                  <%= planned_expense.description %>
+                <% end %>
                 <span class="text-sm font-medium text-gray-700"><%= number_to_currency(planned_expense.amount) %></span>
               </div>
               <p class="mt-1 text-xs text-gray-500">

--- a/db/migrate/20260508014200_add_origin_income_event_to_planned_expenses.rb
+++ b/db/migrate/20260508014200_add_origin_income_event_to_planned_expenses.rb
@@ -15,7 +15,7 @@ class AddOriginIncomeEventToPlannedExpenses < ActiveRecord::Migration[8.0]
       [ :origin_income_event_id, :loan_installment_number ],
       unique: true,
       where: "loan_installment_number IS NOT NULL AND origin_income_event_id IS NOT NULL",
-      name: "index_planned_expenses_on_origin_income_event_and_loan_installment"
+      name: "idx_planned_expenses_on_origin_event_installment"
 
     add_index :planned_expenses,
       [ :income_event_id, :loan_installment_number ],
@@ -26,7 +26,7 @@ class AddOriginIncomeEventToPlannedExpenses < ActiveRecord::Migration[8.0]
 
   def down
     remove_index :planned_expenses,
-      name: "index_planned_expenses_on_origin_income_event_and_loan_installment"
+      name: "idx_planned_expenses_on_origin_event_installment"
 
     remove_index :planned_expenses,
       name: "index_planned_expenses_on_income_event_and_loan_installment"

--- a/db/migrate/20260508014200_add_origin_income_event_to_planned_expenses.rb
+++ b/db/migrate/20260508014200_add_origin_income_event_to_planned_expenses.rb
@@ -1,0 +1,42 @@
+class AddOriginIncomeEventToPlannedExpenses < ActiveRecord::Migration[8.0]
+  def up
+    add_reference :planned_expenses, :origin_income_event, null: true, foreign_key: { to_table: :income_events }
+
+    execute <<~SQL
+      UPDATE planned_expenses
+      SET origin_income_event_id = income_event_id
+      WHERE loan_installment_number IS NOT NULL
+    SQL
+
+    remove_index :planned_expenses,
+      name: "index_planned_expenses_on_income_event_and_loan_installment"
+
+    add_index :planned_expenses,
+      [ :origin_income_event_id, :loan_installment_number ],
+      unique: true,
+      where: "loan_installment_number IS NOT NULL AND origin_income_event_id IS NOT NULL",
+      name: "index_planned_expenses_on_origin_income_event_and_loan_installment"
+
+    add_index :planned_expenses,
+      [ :income_event_id, :loan_installment_number ],
+      unique: true,
+      where: "loan_installment_number IS NOT NULL AND origin_income_event_id IS NULL",
+      name: "index_planned_expenses_on_income_event_and_loan_installment"
+  end
+
+  def down
+    remove_index :planned_expenses,
+      name: "index_planned_expenses_on_origin_income_event_and_loan_installment"
+
+    remove_index :planned_expenses,
+      name: "index_planned_expenses_on_income_event_and_loan_installment"
+
+    add_index :planned_expenses,
+      [ :income_event_id, :loan_installment_number ],
+      unique: true,
+      where: "loan_installment_number IS NOT NULL",
+      name: "index_planned_expenses_on_income_event_and_loan_installment"
+
+    remove_reference :planned_expenses, :origin_income_event, foreign_key: { to_table: :income_events }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -316,6 +316,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
     t.bigint "financial_account_id"
     t.bigint "financial_liability_id"
     t.bigint "income_event_id", null: false
+    t.bigint "origin_income_event_id"
     t.integer "loan_installment_number"
     t.text "notes"
     t.integer "position"
@@ -328,8 +329,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
     t.index ["expense_template_id"], name: "index_planned_expenses_on_expense_template_id"
     t.index ["financial_account_id"], name: "index_planned_expenses_on_financial_account_id"
     t.index ["financial_liability_id"], name: "index_planned_expenses_on_financial_liability_id"
-    t.index ["income_event_id", "loan_installment_number"], name: "index_planned_expenses_on_income_event_and_loan_installment", unique: true, where: "(loan_installment_number IS NOT NULL)"
+    t.index ["income_event_id", "loan_installment_number"], name: "index_planned_expenses_on_income_event_and_loan_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NULL))"
+    t.index ["origin_income_event_id", "loan_installment_number"], name: "index_planned_expenses_on_origin_income_event_and_loan_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NOT NULL))"
     t.index ["income_event_id"], name: "index_planned_expenses_on_income_event_id"
+    t.index ["origin_income_event_id"], name: "index_planned_expenses_on_origin_income_event_id"
     t.index ["shopping_item_id"], name: "index_planned_expenses_on_shopping_item_id"
   end
 
@@ -542,6 +545,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
   add_foreign_key "planned_expenses", "financial_accounts", column: "counterparty_financial_account_id"
   add_foreign_key "planned_expenses", "financial_liabilities"
   add_foreign_key "planned_expenses", "income_events"
+  add_foreign_key "planned_expenses", "income_events", column: "origin_income_event_id"
   add_foreign_key "planned_expenses", "shopping_items"
   add_foreign_key "project_docs", "docs"
   add_foreign_key "project_docs", "projects"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -330,7 +330,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
     t.index ["financial_account_id"], name: "index_planned_expenses_on_financial_account_id"
     t.index ["financial_liability_id"], name: "index_planned_expenses_on_financial_liability_id"
     t.index ["income_event_id", "loan_installment_number"], name: "index_planned_expenses_on_income_event_and_loan_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NULL))"
-    t.index ["origin_income_event_id", "loan_installment_number"], name: "index_planned_expenses_on_origin_income_event_and_loan_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NOT NULL))"
+    t.index ["origin_income_event_id", "loan_installment_number"], name: "idx_planned_expenses_on_origin_event_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NOT NULL))"
     t.index ["income_event_id"], name: "index_planned_expenses_on_income_event_id"
     t.index ["origin_income_event_id"], name: "index_planned_expenses_on_origin_income_event_id"
     t.index ["shopping_item_id"], name: "index_planned_expenses_on_shopping_item_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_08_014200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -316,9 +316,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
     t.bigint "financial_account_id"
     t.bigint "financial_liability_id"
     t.bigint "income_event_id", null: false
-    t.bigint "origin_income_event_id"
     t.integer "loan_installment_number"
     t.text "notes"
+    t.bigint "origin_income_event_id"
     t.integer "position"
     t.bigint "shopping_item_id"
     t.string "status", null: false
@@ -330,8 +330,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_07_000000) do
     t.index ["financial_account_id"], name: "index_planned_expenses_on_financial_account_id"
     t.index ["financial_liability_id"], name: "index_planned_expenses_on_financial_liability_id"
     t.index ["income_event_id", "loan_installment_number"], name: "index_planned_expenses_on_income_event_and_loan_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NULL))"
-    t.index ["origin_income_event_id", "loan_installment_number"], name: "idx_planned_expenses_on_origin_event_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NOT NULL))"
     t.index ["income_event_id"], name: "index_planned_expenses_on_income_event_id"
+    t.index ["origin_income_event_id", "loan_installment_number"], name: "idx_planned_expenses_on_origin_event_installment", unique: true, where: "((loan_installment_number IS NOT NULL) AND (origin_income_event_id IS NOT NULL))"
     t.index ["origin_income_event_id"], name: "index_planned_expenses_on_origin_income_event_id"
     t.index ["shopping_item_id"], name: "index_planned_expenses_on_shopping_item_id"
   end


### PR DESCRIPTION
### Motivation
- Allow planned expenses created from loan schedules to retain their originating `IncomeEvent` so they can be moved without conflicting with loan installment uniqueness constraints.
- Prevent accidental blocking of moves for installments that originated from a loan by treating origin events as the canonical owner of the installment number.

### Description
- Added `origin_income_event_id` reference to `planned_expenses` with foreign key and updated schema and partial unique indexes to enforce uniqueness per origin or current income event respectively.
- Introduced `belongs_to :origin_income_event` in `PlannedExpense` and `has_many :originated_planned_expenses` in `IncomeEvent` to model the origin relationship.
- Set `planned.origin_income_event = loan` when creating/updating loan-generated planned expenses in `Loans::PlannedExpenseSyncService#assign_attributes`.
- Modified `PlannedExpensesController#ensure_unique_installment_for!` to skip the conflict check when `planned_expense.origin_income_event_id` is present so origin-based installments do not block moves.

### Testing
- Applied the migration via `rails db:migrate` against the development schema and verified the new column and indexes were created successfully.
- Ran the automated test suite with `bundle exec rspec` and confirmed tests related to planned expenses, loans, and migrations passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd3c224c6483329d81054b3e611e41)