### PR TITLE
Enhance theme palette and harmonize UI styling across views

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,6 +1,14 @@
 @import "tailwindcss";
 @import "./shadcn.css";
 
+/* Use Poppins from Google Fonts to match diego-blog-w-astro */
+html, body { font-family: 'Poppins', sans-serif; }
+
+body {
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+}
+
 @keyframes slide-in-right {
   from {
     transform: translateX(100%);
@@ -71,7 +79,7 @@
 }
 
 .markdown-content code {
-  background-color: #f1f5f9;
+  background-color: var(--color-muted);
   padding: 0.2em 0.4em;
   border-radius: 3px;
   font-size: 0.9em;
@@ -79,8 +87,8 @@
 }
 
 .markdown-content pre {
-  background-color: #1e293b;
-  color: #e2e8f0;
+  background-color: var(--color-card);
+  color: var(--color-card-foreground);
   padding: 1em;
   border-radius: 5px;
   overflow-x: auto;
@@ -94,51 +102,41 @@
 }
 
 .markdown-content blockquote {
-  border-left: 4px solid #cbd5e1;
+  border-left: 4px solid var(--color-border);
   padding-left: 1em;
   margin-left: 0;
   margin-bottom: 1em;
-  color: #64748b;
+  color: var(--color-muted-foreground);
   font-style: italic;
-}
-
-.markdown-content a {
-  color: #3b82f6;
-  text-decoration: underline;
-}
-
-.markdown-content a:hover {
-  color: #2563eb;
 }
 
 .markdown-content strong {
   font-weight: 700;
 }
 
-.markdown-content em {
-  font-style: italic;
+.markdown-content a {
+  color: var(--color-accent);
+  text-decoration: underline;
 }
 
-.markdown-content table {
-  border-collapse: collapse;
-  width: 100%;
-  margin-bottom: 1em;
+.markdown-content a:hover {
+  color: hsl(var(--primary));
 }
 
 .markdown-content th,
 .markdown-content td {
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--color-border);
   padding: 0.5em 1em;
   text-align: left;
 }
 
 .markdown-content th {
-  background-color: #f8fafc;
+  background-color: var(--color-muted);
   font-weight: 600;
 }
 
 .markdown-content hr {
   border: none;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--color-border);
   margin: 1.5em 0;
 }

--- a/app/assets/tailwind/shadcn.css
+++ b/app/assets/tailwind/shadcn.css
@@ -1,73 +1,364 @@
 /* Shadcn Design System Variables and Theme */
 
 :root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
-  --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
-  --popover: 0 0% 100%;
-  --popover-foreground: 222.2 84% 4.9%;
-  --primary: 222.2 47.4% 11.2%;
+  /*
+    Day mode governance (60-30-10):
+    - 60% base neutrals: background/card/popover
+    - 30% secondary surfaces: secondary/muted/sidebar layers
+    - 10% accents: primary/accent/status tokens for actions and meaning
+    Usage rules:
+    - primary = main CTA only
+    - accent = links/highlighted interactive cues
+    - success/warning/danger = semantic meaning only, never decorative fill
+    Target: WCAG AA contrast for text, controls, and focus indicators.
+  */
+  --background: 0 0% 97%;             /* #F7F7F7 */
+  --foreground: 240 3% 13%;           /* #1F1F21 */
+  --card: 35 24% 98%;
+  --card-foreground: 240 3% 13%;
+  --popover: 35 24% 98%;
+  --popover-foreground: 240 3% 13%;
+  --primary: 211 100% 50%;            /* #007AFF */
   --primary-foreground: 210 40% 98%;
-  --secondary: 210 40% 96.1%;
-  --secondary-foreground: 222.2 47.4% 11.2%;
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
-  --accent: 210 40% 96.1%;
-  --accent-foreground: 222.2 47.4% 11.2%;
-  --destructive: 0 84.2% 60.2%;
+  --secondary: 35 19% 90%;
+  --secondary-foreground: 240 3% 13%;
+  --muted: 228 8% 87%;
+  --muted-foreground: 240 2% 57%;     /* #8E8E93 */
+  --accent: 241 61% 59%;              /* #5856D6 */
+  --accent-foreground: 210 40% 98%;
+  --destructive: 3 100% 59%;          /* #FF3B30 */
   --destructive-foreground: 210 40% 98%;
-  --border: 214.3 31.8% 91.4%;
-  --input: 214.3 31.8% 91.4%;
-  --ring: 221.2 83.2% 53.3%;
-  --chart-1: 12 76% 61%;
-  --chart-2: 173 58% 39%;
-  --chart-3: 197 37% 24%;
-  --chart-4: 43 74% 66%;
-  --chart-5: 27 87% 67%;
-  --sidebar-background: 0 0% 100%;
-  --sidebar-foreground: 222.2 84% 4.9%;
-  --sidebar-primary: 222.2 47.6% 11.2%;
+  --border: 228 8% 78%;
+  --input: 228 8% 78%;
+  --ring: 211 100% 50%;
+  --success: 130 65% 57%;             /* #4CD964 */
+  --success-foreground: 130 55% 12%;
+  --warning: 35 100% 50%;             /* #FF9500 */
+  --warning-foreground: 35 80% 12%;
+  --danger: 349 100% 59%;             /* #FF2D55 */
+  --danger-foreground: 355 70% 96%;
+  --secondary-accent: 198 71% 53%;    /* #34AADC */
+  --secondary-accent-foreground: 198 70% 96%;
+  --chart-1: 211 100% 50%;            /* #007AFF */
+  --chart-2: 198 71% 53%;             /* #34AADC */
+  --chart-3: 199 94% 67%;             /* #5AC8FA */
+  --chart-4: 130 65% 57%;             /* #4CD964 */
+  --chart-5: 48 100% 50%;             /* #FFCC00 */
+  --sidebar-background: 35 18% 94%;
+  --sidebar-foreground: 240 3% 13%;
+  --sidebar-primary: 211 100% 50%;
   --sidebar-primary-foreground: 210 40% 98%;
-  --sidebar-accent: 210 40% 96%;
-  --sidebar-accent-foreground: 222.2 47.6% 11.2%;
-  --sidebar-border: 214.3 31.8% 91.4%;
-  --sidebar-ring: 222.2 84% 4.9%;
+  --sidebar-accent: 228 8% 87%;
+  --sidebar-accent-foreground: 240 3% 13%;
+  --sidebar-border: 228 8% 78%;
+  --sidebar-ring: 212.7 26.8% 83.9%;
+  --accent-dark: 211 100% 42%;
+  --box-shadow-lg: 0 14px 28px rgba(15, 23, 42, 0.08);
+  --shell-gradient-start: 42 20% 97%;
+  --shell-gradient-end: 223 24% 93%;
+  --shell-header-bg: 35 22% 95%;
+  --shell-main-surface: 35 26% 98%;
+  --shell-main-shadow: 0 22px 52px rgba(15, 23, 42, 0.10);
 }
 
 .dark {
-  --background: 222.2 84% 4.9%;
+  /* iOS dark-inspired neutrals + same accent family */
+  --background: 240 6% 11%;
   --foreground: 210 40% 98%;
-  --card: 222.2 84% 4.9%;
+  --card: 240 4% 16%;
   --card-foreground: 210 40% 98%;
-  --popover: 222.2 84% 4.9%;
+  --popover: 240 4% 16%;
   --popover-foreground: 210 40% 98%;
-  --primary: 210 40% 98%;
-  --primary-foreground: 222.2 47.4% 11.2%;
-  --secondary: 217.2 32.6% 17.5%;
+  --primary: 241 61% 67%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 240 4% 27%;
   --secondary-foreground: 210 40% 98%;
-  --muted: 217.2 32.6% 17.5%;
-  --muted-foreground: 215 20.2% 65.1%;
-  --accent: 217.2 32.6% 17.5%;
+  --muted: 240 4% 22%;
+  --muted-foreground: 240 3% 65%;
+  --accent: 211 100% 60%;
   --accent-foreground: 210 40% 98%;
-  --destructive: 0 62.8% 30.6%;
+  --destructive: 3 100% 62%;
   --destructive-foreground: 210 40% 98%;
-  --border: 217.2 32.6% 17.5%;
-  --input: 217.2 32.6% 17.5%;
-  --ring: 224.3 76.3% 48%;
-  --chart-1: 220 70% 50%;
-  --chart-2: 160 60% 45%;
-  --chart-3: 30 80% 55%;
-  --chart-4: 280 65% 60%;
-  --chart-5: 340 75% 55%;
-  --sidebar-background: 222.2 84% 4.9%;
+  --border: 240 4% 27%;
+  --input: 240 4% 27%;
+  --ring: 241 61% 67%;
+  --success: 130 65% 57%;
+  --success-foreground: 146 72% 10%;
+  --warning: 35 100% 56%;
+  --warning-foreground: 34 74% 11%;
+  --danger: 349 100% 64%;
+  --danger-foreground: 3 72% 10%;
+  --secondary-accent: 198 71% 60%;
+  --secondary-accent-foreground: 198 40% 11%;
+  --chart-1: 211 100% 60%;
+  --chart-2: 198 71% 60%;
+  --chart-3: 199 94% 72%;
+  --chart-4: 130 65% 60%;
+  --chart-5: 48 100% 58%;
+  --sidebar-background: 240 6% 13%;
   --sidebar-foreground: 210 40% 98%;
-  --sidebar-primary: 210 40% 98%;
-  --sidebar-primary-foreground: 222.2 47.6% 11.2%;
-  --sidebar-accent: 217.2 32.6% 17.5%;
+  --sidebar-primary: 241 61% 67%;
+  --sidebar-primary-foreground: 210 40% 98%;
+  --sidebar-accent: 240 4% 24%;
   --sidebar-accent-foreground: 210 40% 98%;
-  --sidebar-border: 217.2 32.6% 17.5%;
+  --sidebar-border: 240 4% 27%;
   --sidebar-ring: 212.7 26.8% 83.9%;
+  --shell-gradient-start: 240 8% 12%;
+  --shell-gradient-end: 236 11% 10%;
+  --shell-header-bg: 240 6% 14%;
+  --shell-main-surface: 240 5% 16%;
+  --shell-main-shadow: 0 24px 54px rgba(2, 6, 23, 0.42);
+}
+
+/* Palette variants for Settings -> General -> Color palette */
+:root.palette-executive-calm {
+  --background: 210 20% 98%;
+  --card: 0 0% 100%;
+  --popover: 0 0% 100%;
+  --secondary: 214 24% 93%;
+  --muted: 215 18% 90%;
+  --border: 214 16% 80%;
+  --input: 214 16% 80%;
+  --primary: 211 100% 50%;           /* #007AFF */
+  --accent: 241 61% 59%;             /* #5856D6 */
+  --secondary-accent: 198 71% 53%;   /* #34AADC */
+  --ring: 211 100% 50%;
+  --sidebar-primary: 211 100% 50%;
+  --accent-dark: 211 100% 42%;
+  --shell-gradient-start: 210 32% 98%;
+  --shell-gradient-end: 220 22% 95%;
+  --shell-header-bg: 214 22% 96%;
+  --shell-main-surface: 210 28% 99%;
+  --sidebar-background: 210 28% 99%;
+  --sidebar-accent: 214 20% 89%;
+  --sidebar-border: 214 15% 80%;
+}
+
+:root.palette-ocean-depth {
+  --background: 205 30% 98%;
+  --card: 0 0% 100%;
+  --popover: 0 0% 100%;
+  --secondary: 205 30% 93%;
+  --muted: 205 22% 90%;
+  --border: 206 17% 80%;
+  --input: 206 17% 80%;
+  --primary: 198 71% 53%;            /* #34AADC */
+  --accent: 211 100% 50%;            /* #007AFF */
+  --secondary-accent: 199 94% 67%;   /* #5AC8FA */
+  --ring: 198 71% 53%;
+  --sidebar-primary: 198 71% 53%;
+  --accent-dark: 198 71% 44%;
+  --shell-gradient-start: 202 44% 98%;
+  --shell-gradient-end: 210 36% 95%;
+  --shell-header-bg: 205 33% 96%;
+  --shell-main-surface: 202 56% 99%;
+  --sidebar-background: 202 56% 99%;
+  --sidebar-accent: 205 27% 89%;
+  --sidebar-border: 207 18% 80%;
+}
+
+:root.palette-forest-mint {
+  --background: 138 20% 98%;
+  --card: 0 0% 100%;
+  --popover: 0 0% 100%;
+  --secondary: 140 20% 93%;
+  --muted: 145 14% 90%;
+  --border: 145 10% 80%;
+  --input: 145 10% 80%;
+  --primary: 130 65% 57%;            /* #4CD964 */
+  --accent: 211 100% 50%;            /* #007AFF */
+  --secondary-accent: 198 71% 53%;   /* #34AADC */
+  --ring: 130 65% 57%;
+  --sidebar-primary: 130 65% 57%;
+  --accent-dark: 130 57% 43%;
+  --shell-gradient-start: 138 34% 98%;
+  --shell-gradient-end: 156 24% 95%;
+  --shell-header-bg: 143 24% 96%;
+  --shell-main-surface: 138 34% 99%;
+  --sidebar-background: 138 34% 99%;
+  --sidebar-accent: 144 16% 89%;
+  --sidebar-border: 145 10% 80%;
+}
+
+:root.palette-sunset-ember {
+  --background: 30 32% 98%;
+  --card: 0 0% 100%;
+  --popover: 0 0% 100%;
+  --secondary: 28 34% 93%;
+  --muted: 20 20% 90%;
+  --border: 20 14% 80%;
+  --input: 20 14% 80%;
+  --primary: 35 100% 50%;            /* #FF9500 */
+  --accent: 349 100% 59%;            /* #FF2D55 */
+  --secondary-accent: 241 61% 59%;   /* #5856D6 */
+  --ring: 35 100% 50%;
+  --sidebar-primary: 35 100% 50%;
+  --accent-dark: 35 100% 43%;
+  --shell-gradient-start: 28 52% 98%;
+  --shell-gradient-end: 14 34% 95%;
+  --shell-header-bg: 26 34% 96%;
+  --shell-main-surface: 30 64% 99%;
+  --sidebar-background: 30 64% 99%;
+  --sidebar-accent: 24 25% 89%;
+  --sidebar-border: 20 14% 80%;
+}
+
+:root.palette-shadcn-default {
+  --background: 0 0% 100%;
+  --foreground: 240 10% 3.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 240 10% 3.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 240 10% 3.9%;
+  --primary: 240 5.9% 10%;
+  --primary-foreground: 0 0% 98%;
+  --secondary: 240 4.8% 95.9%;
+  --secondary-foreground: 240 5.9% 10%;
+  --muted: 240 4.8% 95.9%;
+  --muted-foreground: 240 3.8% 46.1%;
+  --accent: 240 4.8% 95.9%;
+  --accent-foreground: 240 5.9% 10%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 5.9% 90%;
+  --input: 240 5.9% 90%;
+  --ring: 240 5.9% 10%;
+  --secondary-accent: 221 83% 53%;
+  --secondary-accent-foreground: 0 0% 98%;
+  --sidebar-background: 0 0% 100%;
+  --sidebar-foreground: 240 10% 3.9%;
+  --sidebar-primary: 240 5.9% 10%;
+  --sidebar-primary-foreground: 0 0% 98%;
+  --sidebar-accent: 240 4.8% 95.9%;
+  --sidebar-accent-foreground: 240 5.9% 10%;
+  --sidebar-border: 240 5.9% 90%;
+  --shell-gradient-start: 0 0% 99%;
+  --shell-gradient-end: 240 6% 96%;
+  --shell-header-bg: 0 0% 100%;
+  --shell-main-surface: 0 0% 100%;
+}
+
+.dark.palette-executive-calm {
+  --background: 225 18% 10%;
+  --card: 228 14% 14%;
+  --popover: 228 14% 14%;
+  --secondary: 228 13% 21%;
+  --muted: 228 10% 18%;
+  --border: 228 11% 27%;
+  --input: 228 11% 27%;
+  --primary: 211 100% 60%;
+  --accent: 241 61% 67%;
+  --secondary-accent: 198 71% 60%;
+  --ring: 211 100% 60%;
+  --sidebar-primary: 211 100% 60%;
+  --shell-gradient-start: 226 18% 11%;
+  --shell-gradient-end: 232 17% 9%;
+  --shell-header-bg: 228 15% 13%;
+  --shell-main-surface: 228 14% 14%;
+  --sidebar-background: 228 15% 12%;
+  --sidebar-accent: 228 11% 20%;
+  --sidebar-border: 228 10% 27%;
+}
+
+.dark.palette-ocean-depth {
+  --background: 210 24% 10%;
+  --card: 210 21% 14%;
+  --popover: 210 21% 14%;
+  --secondary: 210 20% 22%;
+  --muted: 210 16% 18%;
+  --border: 210 14% 27%;
+  --input: 210 14% 27%;
+  --primary: 198 71% 60%;
+  --accent: 211 100% 60%;
+  --secondary-accent: 199 94% 72%;
+  --ring: 198 71% 60%;
+  --sidebar-primary: 198 71% 60%;
+  --shell-gradient-start: 206 28% 11%;
+  --shell-gradient-end: 220 22% 9%;
+  --shell-header-bg: 209 19% 13%;
+  --shell-main-surface: 210 21% 14%;
+  --sidebar-background: 208 20% 12%;
+  --sidebar-accent: 209 14% 20%;
+  --sidebar-border: 210 13% 27%;
+}
+
+.dark.palette-forest-mint {
+  --background: 156 14% 10%;
+  --card: 156 13% 14%;
+  --popover: 156 13% 14%;
+  --secondary: 156 12% 22%;
+  --muted: 156 9% 18%;
+  --border: 156 8% 27%;
+  --input: 156 8% 27%;
+  --primary: 130 65% 60%;
+  --accent: 211 100% 60%;
+  --secondary-accent: 198 71% 60%;
+  --ring: 130 65% 60%;
+  --sidebar-primary: 130 65% 60%;
+  --shell-gradient-start: 150 20% 11%;
+  --shell-gradient-end: 182 15% 9%;
+  --shell-header-bg: 154 13% 13%;
+  --shell-main-surface: 156 13% 14%;
+  --sidebar-background: 156 13% 12%;
+  --sidebar-accent: 155 10% 20%;
+  --sidebar-border: 156 8% 27%;
+}
+
+.dark.palette-sunset-ember {
+  --background: 20 17% 10%;
+  --card: 20 15% 14%;
+  --popover: 20 15% 14%;
+  --secondary: 20 14% 22%;
+  --muted: 20 11% 18%;
+  --border: 20 10% 27%;
+  --input: 20 10% 27%;
+  --primary: 35 100% 56%;
+  --accent: 349 100% 64%;
+  --secondary-accent: 241 61% 67%;
+  --ring: 35 100% 56%;
+  --sidebar-primary: 35 100% 56%;
+  --shell-gradient-start: 22 22% 11%;
+  --shell-gradient-end: 338 15% 9%;
+  --shell-header-bg: 22 16% 13%;
+  --shell-main-surface: 20 15% 14%;
+  --sidebar-background: 20 15% 12%;
+  --sidebar-accent: 20 12% 20%;
+  --sidebar-border: 20 10% 27%;
+}
+
+.dark.palette-shadcn-default {
+  --background: 240 10% 3.9%;
+  --foreground: 0 0% 98%;
+  --card: 240 10% 3.9%;
+  --card-foreground: 0 0% 98%;
+  --popover: 240 10% 3.9%;
+  --popover-foreground: 0 0% 98%;
+  --primary: 0 0% 98%;
+  --primary-foreground: 240 5.9% 10%;
+  --secondary: 240 3.7% 15.9%;
+  --secondary-foreground: 0 0% 98%;
+  --muted: 240 3.7% 15.9%;
+  --muted-foreground: 240 5% 64.9%;
+  --accent: 240 3.7% 15.9%;
+  --accent-foreground: 0 0% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 0 0% 98%;
+  --border: 240 3.7% 15.9%;
+  --input: 240 3.7% 15.9%;
+  --ring: 240 4.9% 83.9%;
+  --secondary-accent: 221 83% 62%;
+  --secondary-accent-foreground: 240 5.9% 10%;
+  --sidebar-background: 240 10% 3.9%;
+  --sidebar-foreground: 0 0% 98%;
+  --sidebar-primary: 0 0% 98%;
+  --sidebar-primary-foreground: 240 5.9% 10%;
+  --sidebar-accent: 240 3.7% 15.9%;
+  --sidebar-accent-foreground: 0 0% 98%;
+  --sidebar-border: 240 3.7% 15.9%;
+  --shell-gradient-start: 240 10% 4%;
+  --shell-gradient-end: 240 8% 6%;
+  --shell-header-bg: 240 10% 3.9%;
+  --shell-main-surface: 240 10% 3.9%;
 }
 
 @theme inline {
@@ -90,6 +381,14 @@
   --color-border: hsl(var(--border));
   --color-input: hsl(var(--input));
   --color-ring: hsl(var(--ring));
+  --color-success: hsl(var(--success));
+  --color-success-foreground: hsl(var(--success-foreground));
+  --color-warning: hsl(var(--warning));
+  --color-warning-foreground: hsl(var(--warning-foreground));
+  --color-danger: hsl(var(--danger));
+  --color-danger-foreground: hsl(var(--danger-foreground));
+  --color-secondary-accent: hsl(var(--secondary-accent));
+  --color-secondary-accent-foreground: hsl(var(--secondary-accent-foreground));
   --color-chart-1: hsl(var(--chart-1));
   --color-chart-2: hsl(var(--chart-2));
   --color-chart-3: hsl(var(--chart-3));
@@ -106,8 +405,19 @@
 }
 
 @layer utilities {
+  /* Level 1 surface: sidebar */
   .bg-sidebar {
     background-color: hsl(var(--sidebar-background));
+    border-right: 1px solid hsl(var(--sidebar-border));
+    box-shadow: 0 10px 22px rgba(16,24,40,0.045);
+    background-image: linear-gradient(180deg, color-mix(in oklab, hsl(var(--sidebar-background)) 95%, hsl(var(--card)) 5%), transparent);
+    background-repeat: no-repeat;
+    background-size: 100% 36%;
+  }
+
+  /* Harmonize hover utilities that use sidebar-accent */
+  .hover\:bg-sidebar-accent:hover {
+    background-color: color-mix(in oklab, hsl(var(--sidebar-accent)) 55%, hsl(var(--card)) 45%);
   }
 
   .text-sidebar-foreground {
@@ -116,6 +426,14 @@
 
   .bg-sidebar-primary {
     background-color: hsl(var(--sidebar-primary));
+    background-image: linear-gradient(180deg, color-mix(in oklab, hsl(var(--sidebar-primary)) 95%, hsl(var(--card)) 5%), hsl(var(--sidebar-primary)));
+    box-shadow: none;
+  }
+
+  /* Hover should increase contrast, not saturation spikes */
+  .nav-link:hover, .hover\:bg-sidebar-accent:hover {
+    background-color: color-mix(in oklab, hsl(var(--card)) 88%, hsl(var(--background)) 12%);
+    color: hsl(var(--foreground));
   }
 
   .text-sidebar-primary-foreground {
@@ -137,6 +455,22 @@
   .ring-sidebar-ring {
     --tw-ring-color: hsl(var(--sidebar-ring));
   }
+
+  .text-success { color: hsl(var(--success)); }
+  .text-danger { color: hsl(var(--danger)); }
+  .text-warning { color: hsl(var(--warning)); }
+  .bg-success-soft { background-color: color-mix(in oklab, hsl(var(--success)) 11%, hsl(var(--card)) 89%); }
+  .bg-danger-soft { background-color: color-mix(in oklab, hsl(var(--danger)) 10%, hsl(var(--card)) 90%); }
+  .bg-warning-soft { background-color: color-mix(in oklab, hsl(var(--warning)) 10%, hsl(var(--card)) 90%); }
+  .border-success-soft { border-color: color-mix(in oklab, hsl(var(--success)) 24%, hsl(var(--border)) 76%); }
+  .border-danger-soft { border-color: color-mix(in oklab, hsl(var(--danger)) 24%, hsl(var(--border)) 76%); }
+  .border-warning-soft { border-color: color-mix(in oklab, hsl(var(--warning)) 24%, hsl(var(--border)) 76%); }
+  .text-secondary-accent { color: hsl(var(--secondary-accent)); }
+  .bg-secondary-accent { background-color: hsl(var(--secondary-accent)); }
+  .bg-secondary-accent-soft { background-color: color-mix(in oklab, hsl(var(--secondary-accent)) 8%, hsl(var(--card)) 92%); }
+  .border-secondary-accent-soft { border-color: color-mix(in oklab, hsl(var(--secondary-accent)) 34%, hsl(var(--border)) 66%); }
+  .bg-accent-soft { background-color: color-mix(in oklab, hsl(var(--accent)) 7%, hsl(var(--card)) 93%); }
+  .bg-warm-soft { background-color: color-mix(in oklab, hsl(var(--secondary)) 48%, hsl(var(--card)) 52%); }
 
   [data-sidebar-target="trigger"][data-trigger-variant="menu"] .hamburger-line {
     transition: transform 200ms ease, opacity 200ms ease, top 200ms ease;
@@ -190,4 +524,148 @@
     opacity: 0;
     pointer-events: none;
   }
+}
+
+@layer components {
+  .ui-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    background-color: hsl(var(--card));
+    color: hsl(var(--card-foreground));
+    border: 1px solid hsl(var(--border));
+    border-radius: 0.75rem;
+    overflow: hidden;
+    font-size: 0.875rem;
+    line-height: 1.35;
+  }
+
+  .ui-table thead tr {
+    background-color: color-mix(in oklab, hsl(var(--muted)) 70%, hsl(var(--card)) 30%);
+    border-bottom: 1px solid hsl(var(--border));
+  }
+
+  .ui-table tbody tr {
+    border-top: 1px solid hsl(var(--border));
+    transition: background-color 140ms ease;
+  }
+
+  .ui-table tbody tr:hover {
+    background-color: color-mix(in oklab, hsl(var(--muted)) 34%, hsl(var(--card)) 66%);
+  }
+
+  .ui-table th {
+    padding: 0.65rem 1rem;
+    text-align: left;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    color: hsl(var(--muted-foreground));
+    text-transform: uppercase;
+  }
+
+  .ui-table td {
+    padding: 0.7rem 1rem;
+    vertical-align: middle;
+    color: hsl(var(--card-foreground));
+  }
+
+  /* Generic button base to improve UX (depth, spacing, transitions) */
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 font-medium transition-colors duration-150;
+  }
+
+  /* Primary button: quiet solid fill with readable contrast */
+  .btn-primary {
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    box-shadow: 0 1px 2px rgba(37, 47, 137, 0.04);
+  }
+
+  .btn-primary:hover {
+    background-color: color-mix(in oklab, hsl(var(--primary)) 94%, black);
+    transform: none;
+    box-shadow: 0 2px 6px rgba(37, 47, 137, 0.06);
+  }
+
+  .btn-primary:active {
+    background-color: color-mix(in oklab, hsl(var(--primary)) 88%, black);
+    box-shadow: 0 1px 1px rgba(37, 47, 137, 0.06);
+  }
+
+  .btn-primary:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in srgb, hsl(var(--primary)) 12%, transparent);
+  }
+
+  /* Secondary / ghost */
+  .btn-secondary {
+    background: color-mix(in oklab, hsl(var(--secondary)) 78%, white);
+    color: hsl(var(--foreground));
+    border: 1px solid hsl(var(--border));
+  }
+
+  .btn-ghost {
+    background: transparent;
+    color: hsl(var(--foreground));
+    border: 1px solid transparent;
+  }
+
+  /* Small utility to ensure adequate contrast for text on accent backgrounds */
+  .text-on-accent { color: hsl(var(--accent-foreground)); }
+}
+
+/* Navigation items */
+@layer components {
+  .nav-link {
+    @apply flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm text-sidebar-foreground transition-colors outline-hidden border border-transparent;
+    font-weight: 500;
+  }
+
+  .nav-link:hover {
+    background-color: color-mix(in oklab, hsl(var(--card)) 92%, hsl(var(--background)) 8%);
+    color: hsl(var(--foreground));
+    box-shadow: none;
+  }
+
+  .nav-link:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 4px color-mix(in srgb, hsl(var(--accent)) 12%, transparent);
+  }
+
+  .nav-link-active {
+    background-color: color-mix(in oklab, hsl(var(--sidebar-accent)) 65%, hsl(var(--card)) 35%);
+    color: hsl(var(--primary));
+    font-weight: 700;
+    border-color: hsl(var(--sidebar-border));
+    box-shadow: none;
+    border-left: 3px solid hsl(var(--primary));
+  }
+}
+
+/* Sidebar header / brand styles */
+@layer components {
+  .sidebar-header {
+    @apply flex items-center gap-3 px-3 py-3 bg-card border-b border-sidebar-border;
+  }
+
+  .sidebar-brand {
+    @apply inline-flex items-center gap-3;
+  }
+
+  .sidebar-brand-badge {
+    @apply flex items-center justify-center rounded-md text-sm font-semibold size-7;
+    background-color: hsl(var(--sidebar-primary));
+    color: hsl(var(--sidebar-primary-foreground));
+    box-shadow: none;
+  }
+
+  /* Slight elevation on hover removed for cleaner look */
+  .nav-link:hover { box-shadow: none; }
+}
+
+/* Accent text utilities */
+@layer utilities {
+  .text-accent { color: hsl(var(--accent)); }
+  .hover\:text-accent-dark:hover { color: hsl(var(--accent-dark)); }
 }

--- a/app/components/app_sidebar_component.html.erb
+++ b/app/components/app_sidebar_component.html.erb
@@ -10,42 +10,42 @@
       <%= render SidebarMenuComponent.new do %>
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/", active: dashboard_active?) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">D</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 10.5L12 3l9 7.5M5.25 9.75V21h13.5V9.75"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.dashboard") %></span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/budget_periods", active: active_controller?("budget_periods")) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">B</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><rect x="3" y="4" width="18" height="17" rx="2" stroke-width="1.8"/><path d="M8 2v4M16 2v4M3 10h18" stroke-linecap="round" stroke-width="1.8"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.budgets") %></span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/income_events", active: active_controller?("income_events", "planned_expenses")) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">I</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M5 19V9m7 10V5m7 14v-7"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 19h18"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.incomes") %></span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/expenses", active: active_controller?("expenses")) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">E</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 7h18M7 3v4m10-4v4M6 11h12l-1 9H7l-1-9z"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.expenses") %></span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/finance", active: finance_active?) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">F</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 10h16M4 14h16M7 6h10M7 18h10"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>">Finance</span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/reports", active: active_controller?("reports")) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">R</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M5 19V9m7 10V5m7 14v-4"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3 19h18"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.reports") %></span>
           <% end %>
         <% end %>
@@ -60,35 +60,35 @@
       <%= render SidebarMenuComponent.new do %>
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/task/recurring_tasks", active: controller_path.include?("task")) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">T</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M9 11l3 3L22 4"/><rect x="2" y="4" width="16" height="16" rx="2" stroke-width="1.8"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.tasks") %></span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/projects", active: controller_path == "projects/projects") do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">P</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 7h16M4 12h10M4 17h16"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>">Projects</span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/docs", active: controller_path == "projects/standalone_docs") do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">D</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M7 3h7l5 5v13H7z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M14 3v5h5"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>">Docs</span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: "/accounts", active: active_controller?("accounts", "account_memberships")) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">A</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M4 20a8 8 0 0 1 16 0"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.accounts") %></span>
           <% end %>
         <% end %>
 
         <%= render SidebarMenuItemComponent.new do %>
           <%= render SidebarMenuButtonComponent.new(href: edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), active: settings_active?) do %>
-            <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">S</span>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" class="text-sidebar-foreground/90" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M10.325 4.317a1 1 0 0 1 1.9 0l.262.79a1 1 0 0 0 .95.69h.833a1 1 0 0 1 .95 1.31l-.262.79a1 1 0 0 0 .364 1.118l.675.49a1 1 0 0 1 0 1.618l-.675.49a1 1 0 0 0-.364 1.118l.262.79a1 1 0 0 1-.95 1.31h-.833a1 1 0 0 0-.95.69l-.262.79a1 1 0 0 1-1.9 0l-.262-.79a1 1 0 0 0-.95-.69h-.833a1 1 0 0 1-.95-1.31l.262-.79a1 1 0 0 0-.364-1.118l-.675-.49a1 1 0 0 1 0-1.618l.675-.49a1 1 0 0 0 .364-1.118l-.262-.79a1 1 0 0 1 .95-1.31h.833a1 1 0 0 0 .95-.69l.262-.79z"/><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M12 14.25a2.25 2.25 0 1 0 0-4.5 2.25 2.25 0 0 0 0 4.5z"/></svg>
             <span data-sidebar-collapse="hide" class="<%= nav_label_classes %>"><%= t("nav.settings") %></span>
           <% end %>
         <% end %>

--- a/app/components/inventory_item_row_component.html.erb
+++ b/app/components/inventory_item_row_component.html.erb
@@ -1,14 +1,14 @@
-<div class="bg-white border rounded p-4 flex items-center justify-between hover:bg-gray-50">
+<div class="bg-card border rounded p-4 flex items-center justify-between hover:bg-muted/35">
   <div class="flex items-center gap-4 flex-1">
     <div class="flex-shrink-0">
       <div class="w-6 h-6 rounded-full <%= stock_indicator_color %>"></div>
     </div>
     <div class="flex-1">
       <h3 class="font-semibold"><%= @inventory_item.name %></h3>
-      <div class="text-sm text-gray-600">
+      <div class="text-sm text-muted-foreground">
         <%= @inventory_item.category&.name || "No category" %>
         <% if @inventory_item.consumable? %>
-          <span class="ml-2 text-xs bg-gray-100 px-2 py-1 rounded">Consumable</span>
+          <span class="ml-2 text-xs bg-muted px-2 py-1 rounded">Consumable</span>
         <% end %>
       </div>
     </div>
@@ -20,11 +20,11 @@
     <% if @inventory_item.stock_state == "empty" || @inventory_item.stock_state == "low" %>
       <%= link_to "Add to Shopping List", add_to_shopping_list_inventory_item_path(@inventory_item), 
           data: { turbo_method: :post }, 
-          class: "px-3 py-1 bg-green-500 text-white rounded hover:bg-green-600 text-sm" %>
+          class: "px-3 py-1 bg-primary text-white rounded hover:bg-primary/90 text-sm" %>
     <% end %>
-    <%= link_to "View", @inventory_item, class: "text-blue-500 hover:underline text-sm" %>
-    <%= link_to "Edit", edit_inventory_item_path(@inventory_item), class: "text-blue-500 hover:underline text-sm ml-2" %>
-    <%= link_to "Delete", @inventory_item, method: :delete, data: { confirm: "Are you sure?" }, class: "text-red-500 hover:underline text-sm ml-2" %>
+    <%= link_to "View", @inventory_item, class: "text-accent hover:underline text-sm" %>
+    <%= link_to "Edit", edit_inventory_item_path(@inventory_item), class: "text-accent hover:underline text-sm ml-2" %>
+    <%= link_to "Delete", @inventory_item, method: :delete, data: { confirm: "Are you sure?" }, class: "text-danger hover:underline text-sm ml-2" %>
   </div>
 </div>
 

--- a/app/components/projects/project_row_component.html.erb
+++ b/app/components/projects/project_row_component.html.erb
@@ -1,12 +1,12 @@
-<div class="flex items-center justify-between p-4 border-b border-slate-200">
+<div class="flex items-center justify-between p-4 border-b border-border">
   <div class="flex-1">
     <div class="flex items-center gap-3">
-      <%= link_to project.name, project_path(project), class: "font-semibold text-blue-600 hover:text-blue-800" %>
+      <%= link_to project.name, project_path(project), class: "font-semibold text-accent hover:text-accent-dark" %>
       <%= render StatusBadgeComponent.new(status: project.status, type: :status) %>
       <%= render StatusBadgeComponent.new(status: project.priority, type: :priority) %>
     </div>
-    <p class="text-sm text-slate-600 mt-1"><%= truncate(project.summary, length: 100) %></p>
-    <div class="flex items-center gap-4 mt-2 text-sm text-slate-500">
+    <p class="text-sm text-muted-foreground mt-1"><%= truncate(project.summary, length: 100) %></p>
+    <div class="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
       <span><%= pluralize(project.tasks.count, "task") %></span>
       <span>Completion: <%= completion_percentage %>%</span>
       <% if project.start_date %>

--- a/app/components/projects/task_row_component.html.erb
+++ b/app/components/projects/task_row_component.html.erb
@@ -1,18 +1,18 @@
-<div class="flex items-center justify-between p-3 border-b border-slate-100 hover:bg-slate-50">
+<div class="flex items-center justify-between p-3 border-b border-border hover:bg-muted/35">
   <div class="flex-1">
     <div class="flex items-center gap-3">
-      <span class="text-xs font-mono text-slate-500"><%= task.task_number %></span>
-      <%= link_to task.title, project_task_path(project, task), class: "font-medium text-blue-600 hover:text-blue-800" %>
+      <span class="text-xs font-mono text-muted-foreground"><%= task.task_number %></span>
+      <%= link_to task.title, project_task_path(project, task), class: "font-medium text-accent hover:text-accent-dark" %>
       <%= render StatusBadgeComponent.new(status: task.status, type: :status) %>
       <%= render StatusBadgeComponent.new(status: task.priority, type: :priority) %>
     </div>
-    <p class="text-sm text-slate-600 mt-1"><%= truncate(task.description, length: 80) %></p>
-    <div class="flex items-center gap-4 mt-2 text-xs text-slate-500">
+    <p class="text-sm text-muted-foreground mt-1"><%= truncate(task.description, length: 80) %></p>
+    <div class="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
       <% if task.user %>
         <span>Owner: <%= task.user.name %></span>
       <% end %>
       <% if task.due_date %>
-        <span class="<%= task.due_date < Date.current ? 'text-red-600 font-semibold' : '' %>">
+        <span class="<%= task.due_date < Date.current ? 'text-danger font-semibold' : '' %>">
           Due: <%= task.due_date.strftime("%b %d, %Y") %>
         </span>
       <% end %>

--- a/app/components/quick_add_menu_component.html.erb
+++ b/app/components/quick_add_menu_component.html.erb
@@ -1,37 +1,46 @@
-<!-- Mobile: Fixed FAB -->
-<div class="fixed bottom-6 right-6 z-40 md:hidden" data-controller="quick-add-menu">
-  <button 
+<!-- Mobile: Floating quick-add button -->
+<div class="fixed right-4 z-40 md:hidden" style="bottom: calc(1rem + env(safe-area-inset-bottom));" data-controller="quick-add-menu">
+  <button
     type="button"
     data-action="click->quick-add-menu#toggleModal"
     data-quick-add-menu-target="fabButton"
-    class="flex items-center justify-center w-14 h-14 rounded-full bg-primary text-primary-foreground shadow-lg hover:bg-primary/90 transition-colors"
+    aria-label="Open quick actions"
+    class="group flex h-14 w-14 items-center justify-center rounded-full border border-primary/35 bg-primary text-primary-foreground shadow-[0_12px_28px_hsl(var(--primary)/0.35)] transition-transform hover:scale-[1.02] hover:bg-primary/92 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
   >
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536M4 20h4.586a1 1 0 0 0 .707-.293l9.414-9.414a1 1 0 0 0 0-1.414L15.121 4.586a1 1 0 0 0-1.414 0L4 14.293V20z" />
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 transition-transform group-hover:rotate-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
     </svg>
   </button>
 </div>
 
-<!-- Desktop: Top-right toolbar buttons -->
-<div class="fixed top-4 right-4 z-40 hidden md:flex items-center gap-2" data-controller="quick-add-menu">
-  <%= link_to quick_add_financial_path, class: "inline-flex items-center gap-2 px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium text-sm", data: { action: "click->quick-add-menu#openFinancial" } do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536M4 20h4.586a1 1 0 0 0 .707-.293l9.414-9.414a1 1 0 0 0 0-1.414L15.121 4.586a1 1 0 0 0-1.414 0L4 14.293V20z" />
-    </svg>
-    <span>💰 Add</span>
-  <% end %>
+<!-- Desktop: Global quick actions (icon-first, expand on hover) -->
+<div class="fixed right-5 top-5 z-40 hidden md:flex" data-controller="quick-add-menu">
+  <div class="inline-flex items-center gap-2 rounded-2xl border border-border/90 bg-card/95 p-2 shadow-sm backdrop-blur">
+    <%= link_to quick_add_financial_path,
+      class: "group inline-flex h-10 w-10 items-center overflow-hidden rounded-xl border border-primary/35 bg-primary px-3 text-primary-foreground shadow-sm transition-all duration-200 hover:w-28 hover:bg-primary/92 focus-visible:w-28 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      data: { action: "click->quick-add-menu#openFinancial" } do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0" />
+      </svg>
+      <span class="ml-0 max-w-0 overflow-hidden whitespace-nowrap text-sm font-semibold opacity-0 transition-all duration-200 group-hover:ml-2 group-hover:max-w-[5rem] group-hover:opacity-100 group-focus-visible:ml-2 group-focus-visible:max-w-[5rem] group-focus-visible:opacity-100">Money</span>
+    <% end %>
 
-  <%= link_to quick_add_task_path, class: "inline-flex items-center gap-2 px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium text-sm", data: { action: "click->quick-add-menu#openTasks" } do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-    <span>✓ Task</span>
-  <% end %>
+    <%= link_to quick_add_task_path,
+      class: "group inline-flex h-10 w-10 items-center overflow-hidden rounded-xl border border-border bg-secondary/55 px-3 text-foreground transition-all duration-200 hover:w-28 hover:bg-secondary/75 focus-visible:w-28 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      data: { action: "click->quick-add-menu#openTasks" } do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+      </svg>
+      <span class="ml-0 max-w-0 overflow-hidden whitespace-nowrap text-sm font-medium opacity-0 transition-all duration-200 group-hover:ml-2 group-hover:max-w-[5rem] group-hover:opacity-100 group-focus-visible:ml-2 group-focus-visible:max-w-[5rem] group-focus-visible:opacity-100">Task</span>
+    <% end %>
 
-  <%= link_to quick_add_doc_path, class: "inline-flex items-center gap-2 px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium text-sm", data: { action: "click->quick-add-menu#openDocs" } do %>
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-    </svg>
-    <span>📄 Doc</span>
-  <% end %>
+    <%= link_to quick_add_doc_path,
+      class: "group inline-flex h-10 w-10 items-center overflow-hidden rounded-xl border border-border bg-secondary/55 px-3 text-foreground transition-all duration-200 hover:w-28 hover:bg-secondary/75 focus-visible:w-28 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      data: { action: "click->quick-add-menu#openDocs" } do %>
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 shrink-0 text-accent" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+      </svg>
+      <span class="ml-0 max-w-0 overflow-hidden whitespace-nowrap text-sm font-medium opacity-0 transition-all duration-200 group-hover:ml-2 group-hover:max-w-[5rem] group-hover:opacity-100 group-focus-visible:ml-2 group-focus-visible:max-w-[5rem] group-focus-visible:opacity-100">Doc</span>
+    <% end %>
+  </div>
 </div>

--- a/app/components/shopping_item_row_component.html.erb
+++ b/app/components/shopping_item_row_component.html.erb
@@ -10,14 +10,14 @@
     <%= render StatusBadgeComponent.new(status: @shopping_item.item_type, type: :item_type, translation_scope: "activerecord.attributes.shopping_item.item_type") %>
   </td>
   <td class="px-4 py-2">
-    <%= link_to "View", @shopping_item, class: "text-blue-500 hover:underline" %>
-    <%= link_to "Edit", edit_shopping_item_path(@shopping_item), class: "text-blue-500 hover:underline ml-2" %>
+    <%= link_to "View", @shopping_item, class: "text-accent hover:underline" %>
+    <%= link_to "Edit", edit_shopping_item_path(@shopping_item), class: "text-accent hover:underline ml-2" %>
     <% if @shopping_item.status == "pending" %>
       <%= link_to "Mark Purchased", mark_as_purchased_shopping_item_path(@shopping_item), 
           data: { turbo_method: :patch }, 
-          class: "text-green-500 hover:underline ml-2" %>
+          class: "text-success hover:underline ml-2" %>
     <% end %>
-    <%= link_to "Delete", @shopping_item, method: :delete, data: { confirm: "Are you sure?" }, class: "text-red-500 hover:underline ml-2" %>
+    <%= link_to "Delete", @shopping_item, method: :delete, data: { confirm: "Are you sure?" }, class: "text-danger hover:underline ml-2" %>
   </td>
 </tr>
 

--- a/app/components/sidebar_footer_component.html.erb
+++ b/app/components/sidebar_footer_component.html.erb
@@ -1,4 +1,14 @@
-<div data-slot="sidebar-footer" data-sidebar="footer" class="mt-auto border-t border-sidebar-border p-2">
+<div data-slot="sidebar-footer" data-sidebar="footer" class="mt-auto border-t border-sidebar-border bg-[color-mix(in_oklab,hsl(var(--sidebar-accent))_20%,hsl(var(--sidebar-background))_80%)] p-2">
+  <div class="mb-2 flex items-center justify-between rounded-md border border-sidebar-border bg-sidebar px-2 py-1.5 text-sm text-sidebar-foreground">
+    <span data-sidebar-collapse="hide" data-theme-target="label">Dark mode</span>
+    <%= render Ui::SwitchComponent.new(
+      id: "theme-mode-switch-footer",
+      checked: false,
+      data: { action: "theme#toggle", theme_target: "switch" },
+      aria_label: "Dark mode"
+    ) %>
+  </div>
+
   <% if defined?(authenticated?) && authenticated? %>
     <details class="group rounded-md">
       <summary class="flex cursor-pointer list-none items-center gap-2 rounded-md px-2 py-1.5 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
@@ -28,6 +38,15 @@
         <% end %>
 
         <%= link_to t("nav.settings"), edit_settings_path, class: "block rounded-md px-2 py-1.5 text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" %>
+        <div class="flex items-center justify-between rounded-md px-2 py-1.5 text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground">
+          <span data-theme-target="label">Dark mode</span>
+          <%= render Ui::SwitchComponent.new(
+            id: "theme-mode-switch",
+            checked: false,
+            data: { action: "theme#toggle", theme_target: "switch" },
+            aria_label: "Dark mode"
+          ) %>
+        </div>
         <%= link_to session_path, data: { turbo_method: :delete }, class: "block rounded-md px-2 py-1.5 text-sm text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" do %>
           <%= t("nav.log_out") %>
         <% end %>

--- a/app/components/sidebar_header_component.html.erb
+++ b/app/components/sidebar_header_component.html.erb
@@ -1,4 +1,4 @@
-<header data-slot="sidebar-header" data-sidebar="header" class="flex flex-col gap-2 border-b border-sidebar-border p-2">
+<header data-slot="sidebar-header" data-sidebar="header" class="flex flex-col gap-2 border-b border-sidebar-border bg-[color-mix(in_oklab,hsl(var(--sidebar-accent))_22%,hsl(var(--sidebar-background))_78%)] p-2">
   <div class="relative flex items-center gap-1">
     <%= link_to "/", class: "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-semibold text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground" do %>
       <span class="flex size-6 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-[10px] font-semibold text-sidebar-primary-foreground">OB</span>

--- a/app/components/sidebar_menu_button_component.rb
+++ b/app/components/sidebar_menu_button_component.rb
@@ -10,7 +10,7 @@ class SidebarMenuButtonComponent < ViewComponent::Base
   attr_reader :href, :active, :class_name
 
   def classes
-    base = "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md px-2 py-1.5 text-left text-sm text-sidebar-foreground outline-hidden transition-all hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0"
+    base = "peer/menu-button group/menu-button relative flex w-full items-center gap-2 overflow-hidden rounded-md border border-transparent px-2 py-1.5 text-left text-sm text-sidebar-foreground outline-hidden transition-all hover:border-sidebar-border hover:bg-sidebar-accent/55 hover:text-foreground focus-visible:ring-2 focus-visible:ring-sidebar-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:border-sidebar-border data-[active=true]:bg-sidebar-accent/70 data-[active=true]:text-primary [&_svg]:size-4 [&_svg]:shrink-0"
     [ base, class_name ].compact.join(" ")
   end
 end

--- a/app/components/ui/button_component.rb
+++ b/app/components/ui/button_component.rb
@@ -2,14 +2,14 @@
 
 module Ui
   class ButtonComponent < ViewComponent::Base
-    BASE_CLASSES = "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 shrink-0 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
+    BASE_CLASSES = "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow,border-color,background-color] outline-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 shrink-0 focus-visible:border-ring focus-visible:ring-ring/40 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive"
 
     VARIANT_CLASSES = {
-      default: "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
-      destructive: "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
-      outline: "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
-      secondary: "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-      ghost: "hover:bg-accent hover:text-accent-foreground",
+      default: "border border-transparent bg-primary text-primary-foreground shadow-sm hover:bg-primary/92",
+      destructive: "border border-transparent bg-destructive text-white shadow-sm hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+      outline: "border border-input bg-card text-foreground shadow-sm hover:bg-muted/60 hover:text-foreground",
+      secondary: "border border-border bg-secondary text-foreground shadow-sm hover:bg-secondary/85",
+      ghost: "border border-transparent hover:bg-muted/55 hover:text-foreground",
       link: "text-primary underline-offset-4 hover:underline shadow-none"
     }.freeze
 

--- a/app/components/ui/switch_component.html.erb
+++ b/app/components/ui/switch_component.html.erb
@@ -1,0 +1,3 @@
+<%= button_tag **button_attributes, data: (button_attributes[:data] || {}).merge(state: state) do %>
+  <span class="<%= Ui::SwitchComponent::THUMB_CLASSES %>"></span>
+<% end %>

--- a/app/components/ui/switch_component.rb
+++ b/app/components/ui/switch_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Ui
+  class SwitchComponent < ViewComponent::Base
+    BASE_CLASSES = "group peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent bg-input transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input".freeze
+    THUMB_CLASSES = "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm ring-0 transition-transform group-data-[state=checked]:translate-x-4 group-data-[state=unchecked]:translate-x-0".freeze
+
+    def initialize(id:, checked: false, disabled: false, aria_label: nil, data: {}, css_class: nil)
+      @id = id
+      @checked = checked
+      @disabled = disabled
+      @aria_label = aria_label
+      @data = data
+      @extra_class = css_class
+    end
+
+    def button_attributes
+      {
+        id: @id,
+        type: "button",
+        role: "switch",
+        "aria-checked": @checked,
+        "aria-label": @aria_label,
+        disabled: @disabled,
+        data: @data.presence,
+        class: [ BASE_CLASSES, @extra_class ].compact.join(" ")
+      }.compact
+    end
+
+    def state
+      @checked ? "checked" : "unchecked"
+    end
+  end
+end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -16,7 +16,7 @@ class SettingsController < ApplicationController
   private
 
   def settings_params
-    params.require(:user).permit(:locale)
+    params.require(:user).permit(:locale, :theme_palette)
   end
 
   def settings_section

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,12 @@
 module ApplicationHelper
+  THEME_PALETTE_OPTIONS = [
+    [ "Executive Calm", "executive-calm" ],
+    [ "Ocean Depth", "ocean-depth" ],
+    [ "Forest Mint", "forest-mint" ],
+    [ "Sunset Ember", "sunset-ember" ],
+    [ "Shadcn Default", "shadcn-default" ]
+  ].freeze
+
   # Returns the current page title for the navbar (e.g. "Expenses", "New expense").
   # Uses content_for(:nav_title) if set, otherwise derives from controller/action and locale.
   def nav_page_title
@@ -69,5 +77,19 @@ module ApplicationHelper
       tags: %w[h1 h2 h3 h4 h5 h6 p br strong em u del code pre blockquote ul ol li a table thead tbody tr th td hr],
       attributes: { "a" => [ "href", "title" ], "th" => [ "align" ], "td" => [ "align" ] }
     )
+  end
+
+  def theme_palette_options
+    THEME_PALETTE_OPTIONS
+  end
+
+  def current_theme_palette
+    raw_palette = Current.user&.theme_palette.presence || "executive-calm"
+    palette = User::LEGACY_THEME_PALETTE_MAP.fetch(raw_palette, raw_palette)
+    User::THEME_PALETTES.include?(palette) ? palette : "executive-calm"
+  end
+
+  def current_theme_palette_class
+    "palette-#{current_theme_palette}"
   end
 end

--- a/app/javascript/controllers/quick_add_menu_controller.js
+++ b/app/javascript/controllers/quick_add_menu_controller.js
@@ -6,22 +6,24 @@ export default class extends Controller {
 
   connect() {
     this.modalOpenValue = false
-    // Listen for turbo:submit-end to close modal on successful form submission
+    this.boundFormSubmitHandler = this.handleFormSubmit.bind(this)
+
     const container = document.getElementById("quick-add-modal-container")
     if (container) {
-      container.addEventListener("turbo:submit-end", this.handleFormSubmit.bind(this))
+      container.addEventListener("turbo:submit-end", this.boundFormSubmitHandler)
     }
   }
 
   disconnect() {
     const container = document.getElementById("quick-add-modal-container")
-    if (container) {
-      container.removeEventListener("turbo:submit-end", this.handleFormSubmit.bind(this))
+    if (container && this.boundFormSubmitHandler) {
+      container.removeEventListener("turbo:submit-end", this.boundFormSubmitHandler)
     }
+
+    this.closeMobileMenu()
   }
 
   handleFormSubmit(event) {
-    // If form was successful (2xx response), close modal
     if (event.detail.formSubmission.result.statusCode >= 200 && event.detail.formSubmission.result.statusCode < 300) {
       this.closeModal()
     }
@@ -32,8 +34,7 @@ export default class extends Controller {
     if (this.modalOpenValue) {
       this.closeModal()
     } else {
-      // On mobile, show a small action menu next to the FAB so users can pick Financial/Task/Doc
-      const isMobile = window.matchMedia && window.matchMedia('(max-width: 767px)').matches
+      const isMobile = window.matchMedia && window.matchMedia("(max-width: 767px)").matches
       if (isMobile) {
         this.openMobileMenu(event?.currentTarget || null)
       } else {
@@ -43,19 +44,18 @@ export default class extends Controller {
   }
 
   openMobileMenu(fabEl) {
-    // Prevent multiple menus
-    if (document.getElementById('quick-add-mobile-menu')) return
+    if (document.getElementById("quick-add-mobile-menu")) return
 
-    const menu = document.createElement('div')
-    menu.id = 'quick-add-mobile-menu'
-    menu.className = 'fixed bottom-20 right-6 z-50 flex flex-col items-end gap-2'
+    const menu = document.createElement("div")
+    menu.id = "quick-add-mobile-menu"
+    menu.className = "fixed bottom-24 right-6 z-50 flex min-w-[10rem] flex-col gap-2 rounded-xl border border-border bg-card/95 p-2 shadow-2xl backdrop-blur"
 
-    const makeBtn = (label, handler) => {
-      const btn = document.createElement('button')
-      btn.type = 'button'
-      btn.className = 'inline-flex items-center gap-2 px-3 py-2 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium text-sm'
-      btn.textContent = label
-      btn.addEventListener('click', e => {
+    const makeBtn = (label, handler, iconPath) => {
+      const btn = document.createElement("button")
+      btn.type = "button"
+      btn.className = "inline-flex items-center gap-2 rounded-md border border-transparent px-3 py-2 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      btn.innerHTML = `<svg xmlns=\"http://www.w3.org/2000/svg\" class=\"h-4 w-4 text-accent\" fill=\"none\" viewBox=\"0 0 24 24\" stroke=\"currentColor\"><path stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" d=\"${iconPath}\" /></svg><span>${label}</span>`
+      btn.addEventListener("click", e => {
         e.preventDefault()
         handler(e)
         this.closeMobileMenu()
@@ -63,26 +63,26 @@ export default class extends Controller {
       return btn
     }
 
-    menu.appendChild(makeBtn('💰 Add', () => this.openFinancial()))
-    menu.appendChild(makeBtn('✓ Task', () => this.openTasks()))
-    menu.appendChild(makeBtn('📄 Doc', () => this.openDocs()))
+    menu.appendChild(makeBtn("Add entry", () => this.openFinancial(), "M12 4v16m8-8H4"))
+    menu.appendChild(makeBtn("Task", () => this.openTasks(), "M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"))
+    menu.appendChild(makeBtn("Doc", () => this.openDocs(), "M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"))
 
     document.body.appendChild(menu)
 
-    // Close when clicking outside
-    this._mobileMenuOutsideHandler = (ev) => {
+    this._mobileMenuOutsideHandler = ev => {
       if (!menu.contains(ev.target) && !(fabEl && fabEl.contains(ev.target))) {
         this.closeMobileMenu()
       }
     }
-    setTimeout(() => window.addEventListener('click', this._mobileMenuOutsideHandler))
+
+    setTimeout(() => window.addEventListener("click", this._mobileMenuOutsideHandler))
   }
 
   closeMobileMenu() {
-    const menu = document.getElementById('quick-add-mobile-menu')
+    const menu = document.getElementById("quick-add-mobile-menu")
     if (menu) menu.remove()
     if (this._mobileMenuOutsideHandler) {
-      window.removeEventListener('click', this._mobileMenuOutsideHandler)
+      window.removeEventListener("click", this._mobileMenuOutsideHandler)
       this._mobileMenuOutsideHandler = null
     }
   }

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,116 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["label", "switch", "paletteSelect"]
+
+  connect() {
+    this.storageKey = "theme"
+    this.paletteStorageKey = "theme_palette"
+    this.palettePrefix = "palette-"
+    this.legacyPaletteMap = {
+      "ios-balanced": "executive-calm",
+      "ios-ocean": "ocean-depth",
+      "ios-forest": "forest-mint",
+      "ios-sunset": "sunset-ember"
+    }
+    this.mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+    this.boundSystemChange = this.handleSystemChange.bind(this)
+    this.mediaQuery.addEventListener("change", this.boundSystemChange)
+
+    this.syncPaletteFromServer()
+    this.applyStoredOrSystemTheme()
+    this.refreshLabel()
+    this.refreshPaletteSelect()
+  }
+
+  disconnect() {
+    this.mediaQuery.removeEventListener("change", this.boundSystemChange)
+  }
+
+  toggle() {
+    const nextTheme = this.isDark() ? "light" : "dark"
+    this.applyTheme(nextTheme)
+    localStorage.setItem(this.storageKey, nextTheme)
+    this.refreshLabel()
+  }
+
+  handleSystemChange() {
+    if (localStorage.getItem(this.storageKey)) return
+    this.applyStoredOrSystemTheme()
+    this.refreshLabel()
+  }
+
+  applyStoredOrSystemTheme() {
+    const stored = localStorage.getItem(this.storageKey)
+    if (stored === "dark" || stored === "light") {
+      this.applyTheme(stored)
+      return
+    }
+
+    this.applyTheme(this.mediaQuery.matches ? "dark" : "light")
+  }
+
+  applyTheme(theme) {
+    document.documentElement.classList.toggle("dark", theme === "dark")
+  }
+
+  changePalette(event) {
+    const palette = event?.target?.value
+    if (!palette) return
+    this.applyPalette(palette)
+    localStorage.setItem(this.paletteStorageKey, palette)
+
+    if (event.target.dataset.autosave === "true") {
+      event.target.form?.requestSubmit()
+    }
+  }
+
+  syncPaletteFromServer() {
+    const serverDefault = this.normalizePalette(document.documentElement.dataset.defaultPalette || "executive-calm")
+    const stored = localStorage.getItem(this.paletteStorageKey)
+    const palette = this.normalizePalette(stored) || serverDefault
+
+    this.applyPalette(palette)
+    localStorage.setItem(this.paletteStorageKey, palette)
+  }
+
+  applyPalette(palette) {
+    const html = document.documentElement
+    html.classList.forEach((cssClass) => {
+      if (cssClass.startsWith(this.palettePrefix)) html.classList.remove(cssClass)
+    })
+    html.classList.add(`${this.palettePrefix}${palette}`)
+  }
+
+  isDark() {
+    return document.documentElement.classList.contains("dark")
+  }
+
+  refreshLabel() {
+    const dark = this.isDark()
+
+    this.labelTargets.forEach((label) => {
+      label.textContent = dark ? "Light mode" : "Dark mode"
+    })
+
+    this.switchTargets.forEach((switchControl) => {
+      switchControl.setAttribute("aria-checked", String(dark))
+      switchControl.dataset.state = dark ? "checked" : "unchecked"
+      switchControl.setAttribute("aria-label", dark ? "Light mode" : "Dark mode")
+    })
+  }
+
+  refreshPaletteSelect() {
+    const htmlClass = Array.from(document.documentElement.classList).find((cssClass) => cssClass.startsWith(this.palettePrefix))
+    if (!htmlClass) return
+    const palette = htmlClass.replace(this.palettePrefix, "")
+    this.paletteSelectTargets.forEach((select) => {
+      select.value = palette
+    })
+  }
+
+  normalizePalette(palette) {
+    if (!palette) return null
+    return this.legacyPaletteMap[palette] || palette
+  }
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,12 @@
 class User < ApplicationRecord
+  THEME_PALETTES = %w[executive-calm ocean-depth forest-mint sunset-ember shadcn-default].freeze
+  LEGACY_THEME_PALETTE_MAP = {
+    "ios-balanced" => "executive-calm",
+    "ios-ocean" => "ocean-depth",
+    "ios-forest" => "forest-mint",
+    "ios-sunset" => "sunset-ember"
+  }.freeze
+
   has_secure_password
   has_many :sessions, dependent: :destroy
   has_many :account_memberships, dependent: :destroy
@@ -10,8 +18,19 @@ class User < ApplicationRecord
   validates :email_address, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }, uniqueness: true
   validates :password, length: { minimum: 8 }, if: -> { new_record? || !password.nil? }
   validates :locale, inclusion: { in: %w[en es] }, allow_nil: true
+  validates :theme_palette, inclusion: { in: THEME_PALETTES }, allow_nil: true
+
+  before_validation :normalize_legacy_theme_palette
 
   def owned_accounts
     accounts.joins(:account_memberships).where(account_memberships: { role: "owner" })
+  end
+
+  private
+
+  def normalize_legacy_theme_palette
+    return if theme_palette.blank?
+
+    self.theme_palette = LEGACY_THEME_PALETTE_MAP.fetch(theme_palette, theme_palette)
   end
 end

--- a/app/views/account_memberships/index.html.erb
+++ b/app/views/account_memberships/index.html.erb
@@ -12,20 +12,20 @@
 <h2 class="text-xl font-semibold mb-4"><%= t("account_memberships.add_member_title") %></h2>
 <%= form_with url: account_account_memberships_path(@account), local: true, class: "mb-6 p-4 border rounded" do |f| %>
   <div class="mb-4">
-    <%= f.label :email_address, t("account_memberships.email_address"), class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.email_field :email_address, required: true, class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    <%= f.label :email_address, t("account_memberships.email_address"), class: "block text-sm font-medium text-foreground mb-1" %>
+    <%= f.email_field :email_address, required: true, class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-primary" %>
   </div>
   <div class="mb-4">
-    <%= f.label :role, "Role", class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.select :role, [['Member', 'member'], ['Owner', 'owner']], {}, { class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" } %>
+    <%= f.label :role, "Role", class: "block text-sm font-medium text-foreground mb-1" %>
+    <%= f.select :role, [['Member', 'member'], ['Owner', 'owner']], {}, { class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-primary" } %>
   </div>
-  <%= f.submit t("account_memberships.add_member"), class: "px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600" %>
+  <%= f.submit t("account_memberships.add_member"), class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary/90" %>
 <% end %>
 
 <h2 class="text-xl font-semibold mb-4">Current Members</h2>
-<table class="min-w-full bg-white border">
+<table class="ui-table">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left">Name</th>
       <th class="px-4 py-2 text-left">Email</th>
       <th class="px-4 py-2 text-left">Role</th>
@@ -52,7 +52,7 @@
             <%= link_to t("account_memberships.remove"), account_account_membership_path(@account, membership), 
                 method: :delete,
                 data: { confirm: t("shared.confirm_remove_member", name: membership.user.name) },
-                class: "px-3 py-1 bg-red-500 text-white text-sm rounded hover:bg-red-600" %>
+                class: "px-3 py-1 bg-danger-soft text-white text-sm rounded hover:bg-danger/90" %>
           <% end %>
         </td>
       </tr>

--- a/app/views/accounts/edit.html.erb
+++ b/app/views/accounts/edit.html.erb
@@ -3,9 +3,9 @@
 
 <%= form_with model: @account, local: true do |f| %>
   <% if @account.errors.any? %>
-    <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded">
-      <h2 class="font-bold text-red-800"><%= t("shared.errors_prohibited_save", count: @account.errors.count, resource: t("activerecord.models.account").downcase) %></h2>
-      <ul class="list-disc list-inside text-red-700">
+    <div class="mb-4 p-4 bg-danger-soft border border-danger-soft rounded">
+      <h2 class="font-bold text-danger"><%= t("shared.errors_prohibited_save", count: @account.errors.count, resource: t("activerecord.models.account").downcase) %></h2>
+      <ul class="list-disc list-inside text-danger">
         <% @account.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -14,12 +14,12 @@
   <% end %>
 
   <div class="mb-4">
-    <%= f.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :name, class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    <%= f.label :name, class: "block text-sm font-medium text-foreground mb-1" %>
+    <%= f.text_field :name, class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-primary" %>
   </div>
 
   <div class="flex space-x-2">
-    <%= f.submit t("accounts.update_account"), class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+    <%= f.submit t("accounts.update_account"), class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
     <%= render Ui::ButtonComponent.new(href: @account,label:"Cancel" ,variant: "ghost") %>
   </div>
 <% end %>

--- a/app/views/accounts/index.html.erb
+++ b/app/views/accounts/index.html.erb
@@ -9,7 +9,7 @@
   <% @accounts.each do |account| %>
     <div class="border rounded p-4 hover:shadow-lg transition-shadow">
       <h2 class="text-xl font-semibold mb-2"><%= account.name %></h2>
-      <p class="text-sm text-gray-600 mb-4">
+      <p class="text-sm text-muted-foreground mb-4">
         <% membership = account.account_memberships.find_by(user: Current.user) %>
         Role: <span class="font-semibold"><%= membership&.role&.capitalize %></span>
       </p>
@@ -24,7 +24,7 @@
           <%= render Ui::ButtonComponent.new(href: edit_account_path(account), label: "Edit", variant: "outline", size: "sm") %>
         <% end %>
         <% if account == current_account %>
-          <span class="px-3 py-1 bg-green-100 text-green-800 text-sm rounded"><%= t("shared.current") %></span>
+          <span class="px-3 py-1 bg-success-soft text-success text-sm rounded"><%= t("shared.current") %></span>
         <% else %>
           <%= form_with url: account_switch_path, method: :post, local: true, class: "inline" do |f| %>
             <%= f.hidden_field :account_id, value: account.id %>

--- a/app/views/accounts/new.html.erb
+++ b/app/views/accounts/new.html.erb
@@ -3,9 +3,9 @@
 
 <%= form_with model: @account, local: true do |f| %>
   <% if @account.errors.any? %>
-    <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded">
-      <h2 class="font-bold text-red-800"><%= pluralize(@account.errors.count, "error") %> prohibited this account from being created:</h2>
-      <ul class="list-disc list-inside text-red-700">
+    <div class="mb-4 p-4 bg-danger-soft border border-danger-soft rounded">
+      <h2 class="font-bold text-danger"><%= pluralize(@account.errors.count, "error") %> prohibited this account from being created:</h2>
+      <ul class="list-disc list-inside text-danger">
         <% @account.errors.full_messages.each do |message| %>
           <li><%= message %></li>
         <% end %>
@@ -14,12 +14,12 @@
   <% end %>
 
   <div class="mb-4">
-    <%= f.label :name, t("accounts.form.name"), class: "block text-sm font-medium text-gray-700 mb-1" %>
-    <%= f.text_field :name, class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+    <%= f.label :name, t("accounts.form.name"), class: "block text-sm font-medium text-foreground mb-1" %>
+    <%= f.text_field :name, class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-primary" %>
   </div>
 
   <div class="flex space-x-2">
-    <%= f.submit t("accounts.create_account"), class: "px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600" %>
+    <%= f.submit t("accounts.create_account"), class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary/90" %>
     <%= render Ui::ButtonComponent.new(href: accounts_path,label:"Cancel", variant: "ghost") %>
   </div>
 <% end %>

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -20,9 +20,9 @@
 </div>
 
 <h2 class="text-xl font-semibold mb-4"><%= t("accounts.show.members") %></h2>
-<table class="min-w-full bg-white border mb-6">
+<table class="min-w-full bg-card border mb-6">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left"><%= t("shared.name") %></th>
       <th class="px-4 py-2 text-left"><%= t("shared.email") %></th>
       <th class="px-4 py-2 text-left"><%= t("shared.role") %></th>

--- a/app/views/budget_periods/_budget_period_card.html.erb
+++ b/app/views/budget_periods/_budget_period_card.html.erb
@@ -1,29 +1,29 @@
-<%= tag.div class: "bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden hover:shadow-lg transition-shadow" do %>
+<%= tag.div class: "bg-card rounded-xl shadow-md border border-border overflow-hidden hover:shadow-lg transition-shadow" do %>
   <div class="px-4 py-4">
-    <h3 class="text-lg font-semibold text-gray-900 mb-2"><%= budget_period.name %></h3>
-    <p class="text-sm text-gray-600 mb-3">
+    <h3 class="text-lg font-semibold text-foreground mb-2"><%= budget_period.name %></h3>
+    <p class="text-sm text-muted-foreground mb-3">
       <%= budget_period.period_type || "-" %> · <%= budget_period.start_date %> – <%= budget_period.end_date %>
     </p>
     <div class="grid grid-cols-3 gap-2 text-sm mb-4">
       <div>
-        <p class="text-gray-500"><%= t("budget_periods.table.total_income") %></p>
+        <p class="text-muted-foreground"><%= t("budget_periods.table.total_income") %></p>
         <p class="font-medium"><%= number_to_currency(budget_period.total_income) %></p>
       </div>
       <div>
-        <p class="text-gray-500"><%= t("budget_periods.table.total_planned") %></p>
+        <p class="text-muted-foreground"><%= t("budget_periods.table.total_planned") %></p>
         <p class="font-medium"><%= number_to_currency(budget_period.total_planned) %></p>
       </div>
       <div>
-        <p class="text-gray-500"><%= t("budget_periods.table.remaining") %></p>
-        <p class="font-semibold <%= budget_period.remaining_budget < 0 ? 'text-red-600' : 'text-green-600' %>">
+        <p class="text-muted-foreground"><%= t("budget_periods.table.remaining") %></p>
+        <p class="font-semibold <%= budget_period.remaining_budget < 0 ? 'text-danger' : 'text-success' %>">
           <%= number_to_currency(budget_period.remaining_budget) %>
         </p>
       </div>
     </div>
     <div class="flex flex-wrap gap-2">
-      <%= link_to t("shared.view"), budget_period, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-600 transition-colors" %>
-      <%= link_to t("shared.edit"), edit_budget_period_path(budget_period), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-gray-200 text-gray-800 text-sm font-medium rounded-lg hover:bg-gray-300 transition-colors" %>
-      <%= link_to t("budget_periods.show.income_events"), budget_period_income_events_path(budget_period), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-green-100 text-green-800 text-sm font-medium rounded-lg hover:bg-green-200 transition-colors" %>
+      <%= link_to t("shared.view"), budget_period, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary transition-colors" %>
+      <%= link_to t("shared.edit"), edit_budget_period_path(budget_period), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-muted text-foreground text-sm font-medium rounded-lg hover:bg-muted/80 transition-colors" %>
+      <%= link_to t("budget_periods.show.income_events"), budget_period_income_events_path(budget_period), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-success-soft text-success text-sm font-medium rounded-lg hover:bg-green-200 transition-colors" %>
     </div>
   </div>
 <% end %>

--- a/app/views/budget_periods/_form.html.erb
+++ b/app/views/budget_periods/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @budget_period, local: true do |form| %>
   <% if @budget_period.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= t("shared.errors_prohibited_save", count: @budget_period.errors.count, resource: t("activerecord.models.budget_period").downcase) %></h2>
       <ul class="list-disc list-inside">
         <% @budget_period.errors.full_messages.each do |message| %>
@@ -11,35 +11,35 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, t("budget_periods.form.name"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, t("budget_periods.form.name"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :period_type, t("budget_periods.form.period_type"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :period_type, t("budget_periods.form.period_type"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :period_type, [[t("budget_periods.form.weekly"), 'weekly'], [t("budget_periods.form.biweekly"), 'biweekly'], [t("budget_periods.form.monthly"), 'monthly'], [t("budget_periods.form.quarterly"), 'quarterly'], [t("budget_periods.form.custom"), 'custom']], { include_blank: t("budget_periods.form.select_period_type") }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4 grid grid-cols-2 gap-4">
     <div>
-      <%= form.label :start_date, t("budget_periods.form.start_date"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.label :start_date, t("budget_periods.form.start_date"), class: "block text-sm font-medium text-foreground mb-1" %>
       <%= form.date_field :start_date, class: "border rounded px-3 py-2 w-full" %>
     </div>
     <div>
-      <%= form.label :end_date, t("budget_periods.form.end_date"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.label :end_date, t("budget_periods.form.end_date"), class: "block text-sm font-medium text-foreground mb-1" %>
       <%= form.date_field :end_date, class: "border rounded px-3 py-2 w-full" %>
     </div>
   </div>
 
   <div class="mb-4">
-    <%= form.label :total_amount, t("budget_periods.form.total_amount"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :total_amount, t("budget_periods.form.total_amount"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :total_amount, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
-    <p class="text-xs text-gray-500 mt-1"><%= t("budget_periods.form.total_amount_note") %></p>
+    <p class="text-xs text-muted-foreground mt-1"><%= t("budget_periods.form.total_amount_note") %></p>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to t("shared.cancel"), @budget_period.persisted? ? @budget_period : budget_periods_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to t("shared.cancel"), @budget_period.persisted? ? @budget_period : budget_periods_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/budget_periods/_income_event_card.html.erb
+++ b/app/views/budget_periods/_income_event_card.html.erb
@@ -1,24 +1,24 @@
-<%= tag.div class: "bg-white rounded-xl border border-gray-200 overflow-hidden hover:shadow-md transition-shadow" do %>
+<%= tag.div class: "bg-card rounded-xl border border-border overflow-hidden hover:shadow-md transition-shadow" do %>
   <div class="px-4 py-4">
     <div class="flex flex-wrap items-start justify-between gap-2 mb-2">
-      <h3 class="text-base font-semibold text-gray-900"><%= income_event.description %></h3>
+      <h3 class="text-base font-semibold text-foreground"><%= income_event.description %></h3>
       <span class="px-2 py-1 rounded text-xs shrink-0 <%= 
         case income_event.status
-        when 'pending' then 'bg-yellow-100 text-yellow-800'
-        when 'received' then 'bg-blue-100 text-blue-800'
-        when 'applied' then 'bg-green-100 text-green-800'
-        else 'bg-gray-100 text-gray-800'
+        when 'pending' then 'bg-warning-soft text-warning'
+        when 'received' then 'bg-muted text-foreground'
+        when 'applied' then 'bg-success-soft text-success'
+        else 'bg-muted text-foreground'
         end
       %>">
         <%= t("income_events.form.#{income_event.status}", default: income_event.status) %>
       </span>
     </div>
-    <p class="text-sm text-gray-600 mb-1">
+    <p class="text-sm text-muted-foreground mb-1">
       <%= t("budget_periods.show.expected_date") %>: <%= income_event.expected_date.strftime("%b %d, %Y") %>
     </p>
-    <p class="text-sm font-medium text-gray-900 mb-3">
+    <p class="text-sm font-medium text-foreground mb-3">
       <%= t("budget_periods.show.expected_amount") %>: <%= number_to_currency(income_event.expected_amount) %>
     </p>
-    <%= link_to t("shared.view"), income_event, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-600 transition-colors" %>
+    <%= link_to t("shared.view"), income_event, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary transition-colors" %>
   </div>
 <% end %>

--- a/app/views/budget_periods/_planned_expense_mobile_item.html.erb
+++ b/app/views/budget_periods/_planned_expense_mobile_item.html.erb
@@ -1,17 +1,17 @@
-<%= tag.div class: "px-4 py-3 border-t border-gray-100 flex flex-col gap-1" do %>
+<%= tag.div class: "px-4 py-3 border-t border-border flex flex-col gap-1" do %>
   <div class="flex justify-between items-start gap-2">
-    <span class="font-medium text-gray-900"><%= planned_expense.category.name %></span>
-    <span class="font-semibold text-gray-900 shrink-0"><%= number_to_currency(planned_expense.amount) %></span>
+    <span class="font-medium text-foreground"><%= planned_expense.category.name %></span>
+    <span class="font-semibold text-foreground shrink-0"><%= number_to_currency(planned_expense.amount) %></span>
   </div>
   <% if planned_expense.description.present? %>
-    <p class="text-sm text-gray-600"><%= planned_expense.description %></p>
+    <p class="text-sm text-muted-foreground"><%= planned_expense.description %></p>
   <% end %>
   <span class="px-2 py-0.5 rounded text-xs w-fit <%= 
     case planned_expense.status
-    when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-yellow-100 text-yellow-800'
-    when 'transferring' then 'bg-blue-100 text-blue-800'
-    when 'paid', 'transferred', 'spent' then 'bg-green-100 text-green-800'
-    else 'bg-gray-100 text-gray-800'
+    when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-warning-soft text-warning'
+    when 'transferring' then 'bg-muted text-foreground'
+    when 'paid', 'transferred', 'spent' then 'bg-success-soft text-success'
+    else 'bg-muted text-foreground'
     end
   %>">
     <%= t("activerecord.attributes.planned_expense.status_options.#{planned_expense.status}", default: planned_expense.status) %>

--- a/app/views/budget_periods/index.html.erb
+++ b/app/views/budget_periods/index.html.erb
@@ -21,9 +21,9 @@
 
     <%# Desktop: table %>
     <div class="hidden md:block overflow-x-auto">
-      <table class="min-w-full bg-white border">
+      <table class="ui-table">
         <thead>
-          <tr class="bg-gray-100">
+          <tr class="bg-muted">
             <th class="px-4 py-2 text-left"><%= t("budget_periods.table.name") %></th>
             <th class="px-4 py-2 text-left"><%= t("budget_periods.table.period_type") %></th>
             <th class="px-4 py-2 text-left"><%= t("budget_periods.table.start_date") %></th>
@@ -43,13 +43,13 @@
               <td class="px-4 py-2"><%= budget_period.end_date %></td>
               <td class="px-4 py-2"><%= number_to_currency(budget_period.total_income) %></td>
               <td class="px-4 py-2"><%= number_to_currency(budget_period.total_planned) %></td>
-              <td class="px-4 py-2 <%= budget_period.remaining_budget < 0 ? 'text-red-600' : 'text-green-600' %>">
+              <td class="px-4 py-2 <%= budget_period.remaining_budget < 0 ? 'text-danger' : 'text-success' %>">
                 <%= number_to_currency(budget_period.remaining_budget) %>
               </td>
               <td class="px-4 py-2">
-                <%= link_to t("shared.view"), budget_period, class: "text-blue-500 hover:underline" %>
-                <%= link_to t("shared.edit"), edit_budget_period_path(budget_period), class: "text-blue-500 hover:underline ml-2" %>
-                <%= link_to t("budget_periods.show.income_events"), budget_period_income_events_path(budget_period), class: "text-green-500 hover:underline ml-2" %>
+                <%= link_to t("shared.view"), budget_period, class: "text-accent hover:underline" %>
+                <%= link_to t("shared.edit"), edit_budget_period_path(budget_period), class: "text-accent hover:underline ml-2" %>
+                <%= link_to t("budget_periods.show.income_events"), budget_period_income_events_path(budget_period), class: "text-success hover:underline ml-2" %>
               </td>
             </tr>
           <% end %>
@@ -57,8 +57,8 @@
       </table>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
-      <p class="text-gray-600 mb-4"><%= t("budget_periods.index.empty_message") %></p>
+    <div class="text-center py-12 bg-card rounded-xl border-2 border-dashed border-input">
+      <p class="text-muted-foreground mb-4"><%= t("budget_periods.index.empty_message") %></p>
       <%= render Ui::ButtonComponent.new(
         href: new_budget_period_path,
         label: t("budget_periods.new_budget_period"),

--- a/app/views/budget_periods/show.html.erb
+++ b/app/views/budget_periods/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="max-w-5xl mx-auto px-4">
   <div class="mb-6">
-    <%= link_to budget_periods_path, class: "inline-flex items-center min-h-[44px] py-2 text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+    <%= link_to budget_periods_path, class: "inline-flex items-center min-h-[44px] py-2 text-accent hover:text-accent-dark transition-colors mb-4" do %>
       <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
       </svg>
@@ -28,36 +28,36 @@
     ) %>
   </div>
 
-<div class="bg-gray-50 p-4 rounded mb-4">
+<div class="bg-muted/35 p-4 rounded mb-4">
   <div class="grid grid-cols-2 gap-4 mb-4">
     <div>
-      <p class="text-sm text-gray-600"><%= t("budget_periods.show.period_type") %></p>
+      <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.period_type") %></p>
       <p class="font-semibold"><%= @budget_period.period_type || "-" %></p>
     </div>
     <div>
-      <p class="text-sm text-gray-600"><%= t("budget_periods.show.total_amount_legacy") %></p>
+      <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.total_amount_legacy") %></p>
       <p class="font-semibold"><%= @budget_period.total_amount ? number_to_currency(@budget_period.total_amount) : "-" %></p>
     </div>
     <div class="col-span-2">
-      <p class="text-sm text-gray-600"><%= t("budget_periods.show.dates") %></p>
+      <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.dates") %></p>
       <p class="font-semibold whitespace-nowrap"><%= @budget_period.start_date.strftime("%b %d, %Y") %> to <%= @budget_period.end_date.strftime("%b %d, %Y") %></p>
     </div>
   </div>
 
-  <div class="mt-4 pt-4 border-t border-gray-200">
-    <h3 class="font-semibold mb-3 text-gray-800"><%= t("budget_periods.show.summary") %></h3>
+  <div class="mt-4 pt-4 border-t border-border">
+    <h3 class="font-semibold mb-3 text-foreground"><%= t("budget_periods.show.summary") %></h3>
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-      <div class="bg-white/60 rounded-lg p-3 border border-gray-100">
-        <p class="text-sm text-gray-600"><%= t("budget_periods.show.total_income") %></p>
+      <div class="bg-card/80 rounded-lg p-3 border border-border">
+        <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.total_income") %></p>
         <p class="font-semibold text-lg"><%= number_to_currency(@budget_period.total_income) %></p>
       </div>
-      <div class="bg-white/60 rounded-lg p-3 border border-gray-100">
-        <p class="text-sm text-gray-600"><%= t("budget_periods.show.total_planned") %></p>
+      <div class="bg-card/80 rounded-lg p-3 border border-border">
+        <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.total_planned") %></p>
         <p class="font-semibold text-lg"><%= number_to_currency(@budget_period.total_planned) %></p>
       </div>
-      <div class="bg-white/60 rounded-lg p-3 border <%= @budget_period.remaining_budget < 0 ? 'border-red-200' : 'border-green-200' %>">
-        <p class="text-sm text-gray-600"><%= t("budget_periods.show.remaining_budget") %></p>
-        <p class="font-semibold text-xl <%= @budget_period.remaining_budget < 0 ? 'text-red-600' : 'text-green-600' %>">
+      <div class="bg-card/80 rounded-lg p-3 border <%= @budget_period.remaining_budget < 0 ? 'border-danger-soft' : 'border-success-soft' %>">
+        <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.remaining_budget") %></p>
+        <p class="font-semibold text-xl <%= @budget_period.remaining_budget < 0 ? 'text-danger' : 'text-success' %>">
           <%= number_to_currency(@budget_period.remaining_budget) %>
         </p>
       </div>
@@ -77,9 +77,9 @@
 
   <%# Desktop: table %>
   <div class="hidden md:block overflow-x-auto mb-6">
-    <table class="min-w-full bg-white border">
+    <table class="ui-table">
       <thead>
-        <tr class="bg-gray-100">
+        <tr class="bg-muted">
           <th class="px-4 py-2 text-left"><%= t("budget_periods.show.expected_date") %></th>
           <th class="px-4 py-2 text-left"><%= t("budget_periods.show.description") %></th>
           <th class="px-4 py-2 text-right whitespace-nowrap"><%= t("budget_periods.show.expected_amount") %></th>
@@ -89,24 +89,24 @@
       </thead>
       <tbody>
         <% @income_events.each do |income_event| %>
-          <tr class="border-t hover:bg-gray-50 transition-colors">
+          <tr class="border-t hover:bg-muted/35 transition-colors">
             <td class="px-4 py-2 whitespace-nowrap"><%= income_event.expected_date.strftime("%b %d, %Y") %></td>
             <td class="px-4 py-2"><%= income_event.description %></td>
             <td class="px-4 py-2 text-right whitespace-nowrap"><%= number_to_currency(income_event.expected_amount) %></td>
             <td class="px-4 py-2">
               <span class="px-2 py-1 rounded text-xs <%= 
                 case income_event.status
-                when 'pending' then 'bg-yellow-100 text-yellow-800'
-                when 'received' then 'bg-blue-100 text-blue-800'
-                when 'applied' then 'bg-green-100 text-green-800'
-                else 'bg-gray-100 text-gray-800'
+                when 'pending' then 'bg-warning-soft text-warning'
+                when 'received' then 'bg-muted text-foreground'
+                when 'applied' then 'bg-success-soft text-success'
+                else 'bg-muted text-foreground'
                 end
               %>">
                 <%= t("income_events.form.#{income_event.status}", default: income_event.status) %>
               </span>
             </td>
             <td class="px-4 py-2">
-              <%= link_to t("shared.view"), income_event, class: "text-blue-500 hover:underline" %>
+              <%= link_to t("shared.view"), income_event, class: "text-accent hover:underline" %>
             </td>
           </tr>
         <% end %>
@@ -114,9 +114,9 @@
     </table>
   </div>
 <% else %>
-  <div class="text-center py-10 px-4 bg-gray-50 rounded-lg border border-gray-200 mb-6">
-    <p class="text-gray-600 mb-3"><%= t("budget_periods.show.no_income_events") %></p>
-    <%= link_to t("budget_periods.show.add_one"), new_budget_period_income_event_path(@budget_period), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-600 transition-colors" %>
+  <div class="text-center py-10 px-4 bg-muted/35 rounded-lg border border-border mb-6">
+    <p class="text-muted-foreground mb-3"><%= t("budget_periods.show.no_income_events") %></p>
+    <%= render Ui::ButtonComponent.new(href: new_budget_period_income_event_path(@budget_period), label: t("budget_periods.show.add_one"), variant: :default) %>
   </div>
 <% end %>
 
@@ -124,30 +124,30 @@
 
 <% if @planned_expenses.any? %>
   <% @planned_expenses.group_by(&:income_event).each do |income_event, planned_expenses| %>
-    <div class="mb-6 border rounded bg-white">
-      <div class="px-4 py-3 bg-gray-50 border-b grid grid-cols-1 sm:grid-cols-[1fr_7rem_8rem_auto] gap-x-6 gap-y-3 sm:gap-y-1 items-baseline">
+    <div class="mb-6 border rounded bg-card">
+      <div class="px-4 py-3 bg-muted/35 border-b grid grid-cols-1 sm:grid-cols-[1fr_7rem_8rem_auto] gap-x-6 gap-y-3 sm:gap-y-1 items-baseline">
         <div class="min-w-0">
-          <p class="text-sm text-gray-600"><%= t("budget_periods.show.income_event") %></p>
+          <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.income_event") %></p>
           <p class="font-semibold">
-            <%= link_to income_event.description, income_event, class: "text-blue-500 hover:underline" %>
+            <%= link_to income_event.description, income_event, class: "text-accent hover:underline" %>
           </p>
         </div>
         <div class="min-w-0">
-          <p class="text-sm text-gray-600"><%= t("budget_periods.show.expected_date") %></p>
+          <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.expected_date") %></p>
           <p class="font-semibold whitespace-nowrap"><%= income_event.expected_date.strftime("%b %d, %Y") %></p>
         </div>
         <div class="min-w-0 text-right">
-          <p class="text-sm text-gray-600"><%= t("budget_periods.show.expected_amount") %></p>
+          <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.expected_amount") %></p>
           <p class="font-semibold whitespace-nowrap"><%= number_to_currency(income_event.expected_amount) %></p>
         </div>
         <div>
-          <p class="text-sm text-gray-600"><%= t("budget_periods.show.status") %></p>
+          <p class="text-sm text-muted-foreground"><%= t("budget_periods.show.status") %></p>
           <span class="px-2 py-1 rounded text-xs <%= 
             case income_event.status
-            when 'pending' then 'bg-yellow-100 text-yellow-800'
-            when 'received' then 'bg-blue-100 text-blue-800'
-            when 'applied' then 'bg-green-100 text-green-800'
-            else 'bg-gray-100 text-gray-800'
+            when 'pending' then 'bg-warning-soft text-warning'
+            when 'received' then 'bg-muted text-foreground'
+            when 'applied' then 'bg-success-soft text-success'
+            else 'bg-muted text-foreground'
             end
           %>">
             <%= t("income_events.form.#{income_event.status}", default: income_event.status) %>
@@ -156,7 +156,7 @@
       </div>
 
       <%# Mobile: compact list of planned expenses %>
-      <div class="md:hidden divide-y divide-gray-100">
+      <div class="md:hidden divide-y divide-border">
         <% planned_expenses.each do |planned_expense| %>
           <%= render partial: "planned_expense_mobile_item", locals: { planned_expense: planned_expense } %>
         <% end %>
@@ -164,9 +164,9 @@
 
       <%# Desktop: table %>
       <div class="hidden md:block overflow-x-auto">
-        <table class="min-w-full bg-white">
+        <table class="ui-table">
           <thead>
-            <tr class="bg-gray-100">
+            <tr class="bg-muted">
               <th class="px-4 py-2 text-left"><%= t("budget_periods.show.income_event") %></th>
               <th class="px-4 py-2 text-left"><%= t("budget_periods.show.expected_date") %></th>
               <th class="px-4 py-2 text-right whitespace-nowrap"><%= t("budget_periods.show.amount") %></th>
@@ -177,9 +177,9 @@
           </thead>
           <tbody>
             <% planned_expenses.each do |planned_expense| %>
-              <tr class="border-t hover:bg-gray-50 transition-colors">
+              <tr class="border-t hover:bg-muted/35 transition-colors">
                 <td class="px-4 py-2">
-                  <%= link_to income_event.description, income_event, class: "text-blue-500 hover:underline" %>
+                  <%= link_to income_event.description, income_event, class: "text-accent hover:underline" %>
                 </td>
                 <td class="px-4 py-2 whitespace-nowrap"><%= income_event.expected_date.strftime("%b %d, %Y") %></td>
                 <td class="px-4 py-2 text-right whitespace-nowrap"><%= number_to_currency(planned_expense.amount) %></td>
@@ -188,10 +188,10 @@
                 <td class="px-4 py-2">
                   <span class="px-2 py-1 rounded text-xs <%= 
                     case planned_expense.status
-                    when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-yellow-100 text-yellow-800'
-                    when 'transferring' then 'bg-blue-100 text-blue-800'
-                    when 'paid', 'transferred', 'spent' then 'bg-green-100 text-green-800'
-                    else 'bg-gray-100 text-gray-800'
+                    when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-warning-soft text-warning'
+                    when 'transferring' then 'bg-muted text-foreground'
+                    when 'paid', 'transferred', 'spent' then 'bg-success-soft text-success'
+                    else 'bg-muted text-foreground'
                     end
                   %>">
                     <%= t("activerecord.attributes.planned_expense.status_options.#{planned_expense.status}", default: planned_expense.status) %>
@@ -205,9 +205,9 @@
     </div>
   <% end %>
 <% else %>
-  <div class="text-center py-12 px-4 bg-gray-50 rounded-lg border border-gray-200">
-    <p class="text-gray-600 mb-4"><%= t("budget_periods.show.no_planned_expenses") %></p>
-    <%= link_to t("budget_periods.show.add_income_event"), new_budget_period_income_event_path(@budget_period), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 bg-blue-500 text-white text-sm font-medium rounded-lg hover:bg-blue-600 transition-colors" %>
+  <div class="text-center py-12 px-4 bg-muted/35 rounded-lg border border-border">
+    <p class="text-muted-foreground mb-4"><%= t("budget_periods.show.no_planned_expenses") %></p>
+    <%= render Ui::ButtonComponent.new(href: new_budget_period_income_event_path(@budget_period), label: t("budget_periods.show.add_income_event"), variant: :default) %>
   </div>
 <% end %>
 </div>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -2,7 +2,7 @@
 <% form_method = @category.persisted? ? :patch : :post %>
 <%= form_with model: @category, url: form_url, method: form_method, local: true do |form| %>
   <% if @category.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= t("shared.errors_prohibited_save", count: @category.errors.count, resource: t("activerecord.models.category").downcase) %></h2>
       <ul class="list-disc list-inside">
         <% @category.errors.full_messages.each do |message| %>
@@ -13,13 +13,13 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, t("categories.form.name"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, t("categories.form.name"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to t("shared.cancel"), @category.persisted? ? finance_category_path(@category) : finance_categories_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to t("shared.cancel"), @category.persisted? ? finance_category_path(@category) : finance_categories_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -10,9 +10,9 @@
     ) %>
 </div>
 
-<table class="min-w-full bg-white border">
+<table class="ui-table">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left"><%= t("shared.name") %></th>
       <th class="px-4 py-2 text-left"><%= t("shared.actions") %></th>
     </tr>
@@ -22,9 +22,9 @@
       <tr class="border-t">
         <td class="px-4 py-2"><%= category.name %></td>
         <td class="px-4 py-2">
-          <%= link_to t("shared.view"), finance_category_path(category), class: "text-blue-500 hover:underline" %>
-          <%= link_to t("shared.edit"), edit_finance_category_path(category), class: "text-blue-500 hover:underline ml-2" %>
-          <%= link_to t("shared.delete"), finance_category_path(category), method: :delete, data: { confirm: t("shared.confirm_destroy_category") }, class: "text-red-500 hover:underline ml-2" %>
+          <%= link_to t("shared.view"), finance_category_path(category), class: "text-accent hover:underline" %>
+          <%= link_to t("shared.edit"), edit_finance_category_path(category), class: "text-accent hover:underline ml-2" %>
+          <%= link_to t("shared.delete"), finance_category_path(category), method: :delete, data: { confirm: t("shared.confirm_destroy_category") }, class: "text-danger hover:underline ml-2" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/categories/show.html.erb
+++ b/app/views/categories/show.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← " + t("categories.show.back"), finance_categories_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← " + t("categories.show.back"), finance_categories_path, class: "text-accent hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @category.name %></h1>
@@ -17,19 +17,19 @@
   ) %>
 </div>
 
-<div class="bg-gray-50 p-4 rounded mb-4">
+<div class="bg-muted/35 p-4 rounded mb-4">
   <h2 class="text-xl font-semibold mb-2">Statistics</h2>
   <div class="grid grid-cols-3 gap-4">
     <div>
-      <p class="text-sm text-gray-600">Expenses</p>
+      <p class="text-sm text-muted-foreground">Expenses</p>
       <p class="font-semibold text-lg"><%= @category.expenses.count %></p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Expense Templates</p>
+      <p class="text-sm text-muted-foreground">Expense Templates</p>
       <p class="font-semibold text-lg"><%= @category.expense_templates.count %></p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Planned Expenses</p>
+      <p class="text-sm text-muted-foreground">Planned Expenses</p>
       <p class="font-semibold text-lg"><%= @category.planned_expenses.count %></p>
     </div>
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,92 +1,91 @@
+<section class="space-y-7 p-6 sm:p-8">
+  <header class="rounded-2xl border border-border bg-card p-6 shadow-sm">
+    <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+      <div class="space-y-2">
+        <h1 class="text-2xl font-bold tracking-tight text-foreground sm:text-3xl"><%= t("dashboard.welcome") %></h1>
+        <p class="max-w-2xl text-sm text-muted-foreground sm:text-base">
+          Focus on your next financial move, then navigate to supporting modules.
+        </p>
+      </div>
 
-<h1 class="text-2xl font-bold mb-4"><%= t("dashboard.welcome") %></h1>
+      <div class="grid w-full max-w-xl grid-cols-1 gap-2 sm:grid-cols-2">
+        <%= render Ui::ButtonComponent.new(href: new_expense_path, label: t("dashboard.add_expense"), variant: :default, css_class: "h-10 w-full justify-start") %>
+        <%= render Ui::ButtonComponent.new(href: new_income_event_path, label: t("dashboard.new_income_event"), variant: :outline, css_class: "h-10 w-full justify-start") %>
+        <%= render Ui::ButtonComponent.new(href: new_budget_period_path, label: t("dashboard.new_budget_period"), variant: :outline, css_class: "h-10 w-full justify-start") %>
+        <%= render Ui::ButtonComponent.new(href: new_shopping_item_path, label: t("dashboard.add_shopping_item"), variant: :ghost, css_class: "h-10 w-full justify-start") %>
+      </div>
+    </div>
+  </header>
 
-<% if Current.account && @due_soon_tasks&.any? %>
-  <section class="mb-6 p-4 border rounded bg-gray-50">
-    <h2 class="text-lg font-semibold mb-2"><%= t("task.recurring_tasks.index.title") %></h2>
-    <ul class="list-disc list-inside space-y-1 mb-2">
-      <% @due_soon_tasks.each do |task| %>
-        <li class="<%= 'text-red-600 font-medium' if task.overdue? %>">
-          <%= task.name %>
-          <% if task.next_due_date %>
-            <span class="text-gray-600 text-sm">(<%= l(task.next_due_date, format: :short) %>)</span>
-          <% end %>
-        </li>
+  <% if Current.account && @due_soon_tasks&.any? %>
+    <section class="rounded-xl border border-warning-soft bg-warning-soft p-4">
+      <div class="mb-2 flex items-center justify-between gap-3">
+        <h2 class="text-base font-semibold text-foreground"><%= t("task.recurring_tasks.index.title") %></h2>
+        <%= link_to t("task.recurring_tasks.index.title"), task_root_path, class: "text-sm font-medium text-accent hover:text-accent-dark hover:underline" %>
+      </div>
+      <ul class="space-y-1.5 text-sm">
+        <% @due_soon_tasks.each do |task| %>
+          <li class="flex items-center justify-between gap-3 rounded-md border border-border bg-card px-3 py-2">
+            <span class="min-w-0 truncate <%= 'font-semibold text-danger' if task.overdue? %>"><%= task.name %></span>
+            <% if task.next_due_date %>
+              <span class="shrink-0 text-xs text-muted-foreground"><%= l(task.next_due_date, format: :short) %></span>
+            <% end %>
+          </li>
+        <% end %>
+      </ul>
+    </section>
+  <% end %>
+
+  <section class="space-y-3">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Core Workspace</h2>
+    <nav class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+      <%= link_to expenses_path, class: "group rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:bg-muted/35" do %>
+        <h3 class="text-base font-semibold text-foreground">Expenses</h3>
+        <p class="mt-1 text-sm text-muted-foreground"><%= t("dashboard.expenses_description") %></p>
       <% end %>
-    </ul>
-    <%= link_to t("task.recurring_tasks.index.title"), task_root_path, class: "text-blue-600 hover:underline text-sm" %>
+
+      <%= link_to income_events_path, class: "group rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:bg-muted/35" do %>
+        <h3 class="text-base font-semibold text-foreground">Income Events</h3>
+        <p class="mt-1 text-sm text-muted-foreground"><%= t("dashboard.income_events_description") %></p>
+      <% end %>
+
+      <%= link_to budget_periods_path, class: "group rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:bg-muted/35" do %>
+        <h3 class="text-base font-semibold text-foreground">Budget Periods</h3>
+        <p class="mt-1 text-sm text-muted-foreground"><%= t("dashboard.budget_periods_description") %></p>
+      <% end %>
+
+      <%= link_to finance_path, class: "group rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:bg-muted/35" do %>
+        <h3 class="text-base font-semibold text-foreground">Finance</h3>
+        <p class="mt-1 text-sm text-muted-foreground">Accounts, liabilities, entries, and repayment flow.</p>
+      <% end %>
+
+      <%= link_to task_root_path, class: "group rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:bg-muted/35" do %>
+        <h3 class="text-base font-semibold text-foreground"><%= t("nav.tasks") %></h3>
+        <p class="mt-1 text-sm text-muted-foreground"><%= t("task.recurring_tasks.index.title") %></p>
+      <% end %>
+
+      <%= link_to reports_path, class: "group rounded-xl border border-border bg-card p-5 shadow-sm transition-colors hover:bg-muted/35" do %>
+        <h3 class="text-base font-semibold text-foreground">Reports</h3>
+        <p class="mt-1 text-sm text-muted-foreground"><%= t("dashboard.reports_description") %></p>
+      <% end %>
+    </nav>
   </section>
-<% end %>
 
-<nav class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-  <%= link_to budget_periods_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">📅 <%= t("dashboard.budget_periods_title") %></h2>
-    <p><%= t("dashboard.budget_periods_description") %></p>
-  <% end %>
-
-  <%= link_to income_events_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">💰 <%= t("dashboard.income_events_title") %></h2>
-    <p><%= t("dashboard.income_events_description") %></p>
-  <% end %>
-
-  <%= link_to expense_templates_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">📋 <%= t("dashboard.expense_templates_title") %></h2>
-    <p><%= t("dashboard.expense_templates_description") %></p>
-  <% end %>
-
-  <%= link_to finance_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">🏦 Finance</h2>
-    <p>Accounts, liabilities, entries, and how repayments fit into the flow.</p>
-  <% end %>
-
-  <%= link_to expenses_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">💸 <%= t("dashboard.expenses_title") %></h2>
-    <p><%= t("dashboard.expenses_description") %></p>
-  <% end %>
-
-  <%= link_to finance_categories_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">🏷️ <%= t("dashboard.categories_title") %></h2>
-    <p><%= t("dashboard.categories_description") %></p>
-  <% end %>
-
-  <%= link_to task_root_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">✓ <%= t("nav.tasks") %></h2>
-    <p><%= t("task.recurring_tasks.index.title") %></p>
-  <% end %>
-
-  <%= link_to shopping_items_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">🛒 <%= t("dashboard.shopping_list_title") %></h2>
-    <p><%= t("dashboard.shopping_list_description") %></p>
-  <% end %>
-
-  <%= link_to inventory_items_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">📦 <%= t("dashboard.home_inventory_title") %></h2>
-    <p><%= t("dashboard.home_inventory_description") %></p>
-  <% end %>
-
-  <%= link_to reports_path, class: "block p-4 border rounded hover:shadow" do %>
-    <h2 class="text-xl">📊 <%= t("dashboard.reports_title") %></h2>
-    <p><%= t("dashboard.reports_description") %></p>
-  <% end %>
-
-  <%= link_to new_budget_period_path, class: "block p-4 border rounded hover:shadow col-span-full" do %>
-    <h2 class="text-xl">➕ <%= t("dashboard.new_budget_period") %></h2>
-  <% end %>
-
-  <%= link_to new_income_event_path, class: "block p-4 border rounded hover:shadow col-span-full" do %>
-    <h2 class="text-xl">➕ <%= t("dashboard.new_income_event") %></h2>
-  <% end %>
-
-  <%= link_to new_expense_path, class: "block p-4 border rounded hover:shadow col-span-full" do %>
-    <h2 class="text-xl">➕ <%= t("dashboard.add_expense") %></h2>
-  <% end %>
-
-  <%= link_to new_shopping_item_path, class: "block p-4 border rounded hover:shadow col-span-full" do %>
-    <h2 class="text-xl">➕ <%= t("dashboard.add_shopping_item") %></h2>
-  <% end %>
-</nav>
-
-<%= render QuickAddMenuComponent.new %>
-
-<!-- Modal container for quick-add modals -->
-<div id="quick-add-modal-container"></div>
+  <section class="space-y-3">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Supporting Modules</h2>
+    <nav class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <%= link_to expense_templates_path, class: "rounded-xl border border-border bg-card p-4 text-sm font-medium text-foreground hover:bg-muted/35" do %>
+        <%= t("dashboard.expense_templates_title") %>
+      <% end %>
+      <%= link_to finance_categories_path, class: "rounded-xl border border-border bg-card p-4 text-sm font-medium text-foreground hover:bg-muted/35" do %>
+        <%= t("dashboard.categories_title") %>
+      <% end %>
+      <%= link_to shopping_items_path, class: "rounded-xl border border-border bg-card p-4 text-sm font-medium text-foreground hover:bg-muted/35" do %>
+        <%= t("dashboard.shopping_list_title") %>
+      <% end %>
+      <%= link_to inventory_items_path, class: "rounded-xl border border-border bg-card p-4 text-sm font-medium text-foreground hover:bg-muted/35" do %>
+        <%= t("dashboard.home_inventory_title") %>
+      <% end %>
+    </nav>
+  </section>
+</section>

--- a/app/views/expense_templates/_form.html.erb
+++ b/app/views/expense_templates/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @expense_template, local: true do |form| %>
   <% if @expense_template.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@expense_template.errors.count, "error") %> prohibited this expense template from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @expense_template.errors.full_messages.each do |message| %>
@@ -11,38 +11,38 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :category_id, "Category", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :category_id, Category.all, :id, :name, { prompt: "Select a category" }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :description, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :description, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :total_amount, "Total Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :total_amount, "Total Amount", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :total_amount, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :frequency, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :frequency, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :frequency, [['Weekly', 'weekly'], ['Biweekly', 'biweekly'], ['Monthly', 'monthly'], ['Bimonthly', 'bimonthly'], ['Quarterly', 'quarterly'], ['Custom', 'custom']], { prompt: "Select frequency" }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", @expense_template.persisted? ? @expense_template : expense_templates_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "btn btn-primary" %>
+    <%= link_to "Cancel", @expense_template.persisted? ? @expense_template : expense_templates_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/expense_templates/index.html.erb
+++ b/app/views/expense_templates/index.html.erb
@@ -2,7 +2,7 @@
 
 <div class="mb-6">
   <div class="flex justify-between items-center mb-6">
-    <h1 class="text-3xl font-bold text-gray-900">Expense Templates</h1>
+    <h1 class="text-3xl font-bold text-foreground">Expense Templates</h1>
     <%= render Ui::ButtonComponent.new(
       href: new_expense_template_path,
       label: "New Expense Template",
@@ -14,25 +14,25 @@
 <% if @expense_templates.any? %>
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
     <% @expense_templates.each do |template| %>
-      <div class="bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-gray-200 overflow-hidden">
+      <div class="bg-card rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-border overflow-hidden">
         <!-- Card Header -->
-        <div class="bg-gradient-to-r from-indigo-50 to-blue-50 px-6 py-4 border-b border-gray-200">
+        <div class="bg-gradient-to-r from-indigo-50 to-blue-50 px-6 py-4 border-b border-border">
           <div class="flex items-center justify-between mb-2">
-            <h3 class="text-lg font-semibold text-gray-900"><%= template.name %></h3>
+            <h3 class="text-lg font-semibold text-foreground"><%= template.name %></h3>
             <% if template.is_complete? %>
-              <span class="px-3 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200 flex items-center gap-1">
+              <span class="px-3 py-1 rounded-full text-xs font-medium bg-success-soft text-success border border-success-soft flex items-center gap-1">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
                 </svg>
                 Complete
               </span>
             <% else %>
-              <span class="px-3 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800 border border-yellow-200">
+              <span class="px-3 py-1 rounded-full text-xs font-medium bg-warning-soft text-warning border border-warning-soft">
                 In Progress
               </span>
             <% end %>
           </div>
-          <div class="flex items-center gap-2 text-sm text-gray-600">
+          <div class="flex items-center gap-2 text-sm text-muted-foreground">
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
             </svg>
@@ -47,10 +47,10 @@
           <!-- Progress Section -->
           <div class="mb-4">
             <div class="flex items-center justify-between mb-2">
-              <span class="text-sm font-medium text-gray-700">Progress</span>
+              <span class="text-sm font-medium text-foreground">Progress</span>
               <span class="text-sm font-bold text-indigo-600"><%= template.progress_percentage.round(1) %>%</span>
             </div>
-            <div class="w-full bg-gray-200 rounded-full h-3 mb-2">
+            <div class="w-full bg-muted rounded-full h-3 mb-2">
               <div class="bg-gradient-to-r from-indigo-500 to-blue-500 h-3 rounded-full transition-all duration-300 flex items-center justify-end pr-1" style="width: <%= [template.progress_percentage, 100].min %>%">
                 <% if template.is_complete? %>
                   <svg class="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -59,21 +59,21 @@
                 <% end %>
               </div>
             </div>
-            <div class="flex items-center justify-between text-xs text-gray-600">
+            <div class="flex items-center justify-between text-xs text-muted-foreground">
               <span><%= number_to_currency(template.total_saved) %> saved</span>
               <span><%= number_to_currency(template.total_amount) %> total</span>
             </div>
           </div>
 
           <!-- Stats Grid -->
-          <div class="grid grid-cols-2 gap-3 pt-4 border-t border-gray-100">
+          <div class="grid grid-cols-2 gap-3 pt-4 border-t border-border">
             <div>
-              <p class="text-xs text-gray-500 mb-1">Total Amount</p>
-              <p class="text-lg font-bold text-gray-900"><%= number_to_currency(template.total_amount) %></p>
+              <p class="text-xs text-muted-foreground mb-1">Total Amount</p>
+              <p class="text-lg font-bold text-foreground"><%= number_to_currency(template.total_amount) %></p>
             </div>
             <div>
-              <p class="text-xs text-gray-500 mb-1">Remaining</p>
-              <p class="text-lg font-bold <%= template.remaining_amount > 0 ? 'text-indigo-600' : 'text-green-600' %>">
+              <p class="text-xs text-muted-foreground mb-1">Remaining</p>
+              <p class="text-lg font-bold <%= template.remaining_amount > 0 ? 'text-indigo-600' : 'text-success' %>">
                 <%= number_to_currency(template.remaining_amount) %>
               </p>
             </div>
@@ -81,7 +81,7 @@
         </div>
 
         <!-- Card Footer -->
-        <div class="bg-gray-50 px-6 py-4 border-t border-gray-200 flex items-center justify-between">
+        <div class="bg-muted/35 px-6 py-4 border-t border-border flex items-center justify-between">
           <%= render Ui::ButtonComponent.new(href: template, label: "View", variant: "outline", size: "sm") do %>
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
@@ -95,12 +95,12 @@
   </div>
 <% else %>
   <!-- Empty State -->
-  <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
+  <div class="text-center py-12 bg-card rounded-xl border-2 border-dashed border-input">
     <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path>
     </svg>
-    <h3 class="mt-2 text-sm font-medium text-gray-900">No expense templates</h3>
-    <p class="mt-1 text-sm text-gray-500">Create templates for recurring expenses like bills and subscriptions.</p>
+    <h3 class="mt-2 text-sm font-medium text-foreground">No expense templates</h3>
+    <p class="mt-1 text-sm text-muted-foreground">Create templates for recurring expenses like bills and subscriptions.</p>
     <div class="mt-6">
       <%= render Ui::ButtonComponent.new(
         href: new_expense_template_path,

--- a/app/views/expense_templates/show.html.erb
+++ b/app/views/expense_templates/show.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-6">
-  <%= link_to expense_templates_path, class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+  <%= link_to expense_templates_path, class: "inline-flex items-center text-accent hover:text-accent-dark transition-colors mb-4" do %>
     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
     </svg>
@@ -30,7 +30,7 @@
       </div>
     </div>
     <% if @expense_template.is_complete? %>
-      <span class="px-4 py-2 rounded-full text-sm font-medium bg-green-500/20 backdrop-blur-sm border border-green-300/30 text-green-100 flex items-center gap-2">
+      <span class="px-4 py-2 rounded-full text-sm font-medium bg-primary/20 backdrop-blur-sm border border-green-300/30 text-green-100 flex items-center gap-2">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
         </svg>
@@ -44,12 +44,12 @@
   </div>
 
   <!-- Large Progress Bar -->
-  <div class="bg-white/10 backdrop-blur-sm rounded-xl p-6 border border-white/20">
+  <div class="bg-card/10 backdrop-blur-sm rounded-xl p-6 border border-white/20">
     <div class="flex items-center justify-between mb-4">
       <h3 class="text-lg font-semibold">Progress Toward Goal</h3>
       <span class="text-2xl font-bold"><%= @expense_template.progress_percentage.round(1) %>%</span>
     </div>
-    <div class="w-full bg-white/20 rounded-full h-6 mb-4 relative overflow-hidden">
+    <div class="w-full bg-card/20 rounded-full h-6 mb-4 relative overflow-hidden">
       <div class="bg-gradient-to-r from-green-400 to-green-500 h-6 rounded-full transition-all duration-500 flex items-center justify-end pr-2" style="width: <%= [@expense_template.progress_percentage, 100].min %>%">
         <% if @expense_template.is_complete? %>
           <svg class="w-4 h-4 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -65,11 +65,11 @@
       </div>
       <div>
         <p class="text-indigo-100 text-sm mb-1">Saved</p>
-        <p class="text-xl font-bold text-green-200"><%= number_to_currency(@expense_template.total_saved) %></p>
+        <p class="text-xl font-bold text-success"><%= number_to_currency(@expense_template.total_saved) %></p>
       </div>
       <div>
         <p class="text-indigo-100 text-sm mb-1">Remaining</p>
-        <p class="text-xl font-bold <%= @expense_template.remaining_amount > 0 ? 'text-yellow-200' : 'text-green-200' %>">
+        <p class="text-xl font-bold <%= @expense_template.remaining_amount > 0 ? 'text-yellow-200' : 'text-success' %>">
           <%= number_to_currency(@expense_template.remaining_amount) %>
         </p>
       </div>
@@ -78,19 +78,19 @@
 </div>
 
 <!-- Details Section -->
-<div class="bg-white rounded-xl shadow-md border border-gray-200 p-6 mb-8">
-  <h2 class="text-xl font-bold text-gray-900 mb-4">Template Details</h2>
+<div class="bg-card rounded-xl shadow-md border border-border p-6 mb-8">
+  <h2 class="text-xl font-bold text-foreground mb-4">Template Details</h2>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
     <% if @expense_template.description.present? %>
       <div>
-        <p class="text-sm font-medium text-gray-500 mb-1">Description</p>
-        <p class="text-gray-900"><%= @expense_template.description %></p>
+        <p class="text-sm font-medium text-muted-foreground mb-1">Description</p>
+        <p class="text-foreground"><%= @expense_template.description %></p>
       </div>
     <% end %>
     <% if @expense_template.notes.present? %>
       <div>
-        <p class="text-sm font-medium text-gray-500 mb-1">Notes</p>
-        <p class="text-gray-900"><%= @expense_template.notes %></p>
+        <p class="text-sm font-medium text-muted-foreground mb-1">Notes</p>
+        <p class="text-foreground"><%= @expense_template.notes %></p>
       </div>
     <% end %>
   </div>
@@ -103,12 +103,12 @@
 
 <!-- Planned Expenses Timeline -->
 <div class="mb-6">
-  <h2 class="text-2xl font-bold text-gray-900 mb-4">Planned Expenses Timeline</h2>
+  <h2 class="text-2xl font-bold text-foreground mb-4">Planned Expenses Timeline</h2>
   
   <% if @planned_expenses.any? %>
     <div class="space-y-4">
       <% @planned_expenses.each do |planned_expense| %>
-        <div class="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-gray-200 p-5">
+        <div class="bg-card rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-border p-5">
           <div class="flex items-start justify-between">
             <div class="flex-1">
               <div class="flex items-center gap-3 mb-2">
@@ -116,19 +116,19 @@
                   <%= number_to_currency(planned_expense.amount) %>
                 </div>
                 <div>
-                  <h3 class="font-semibold text-gray-900">
+                  <h3 class="font-semibold text-foreground">
                     <%= link_to planned_expense.income_event.description, planned_expense.income_event, class: "hover:text-indigo-600 transition-colors" %>
                   </h3>
-                  <p class="text-sm text-gray-500"><%= planned_expense.created_at.strftime("%B %d, %Y") %></p>
+                  <p class="text-sm text-muted-foreground"><%= planned_expense.created_at.strftime("%B %d, %Y") %></p>
                 </div>
               </div>
             </div>
             <span class="px-3 py-1 rounded-full text-xs font-medium <%= 
               case planned_expense.status
-              when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-yellow-100 text-yellow-800 border border-yellow-200'
-              when 'transferring' then 'bg-blue-100 text-blue-800 border border-blue-200'
-              when 'paid', 'transferred', 'spent' then 'bg-green-100 text-green-800 border border-green-200'
-              else 'bg-gray-100 text-gray-800 border border-gray-200'
+              when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-warning-soft text-warning border border-warning-soft'
+              when 'transferring' then 'bg-muted text-foreground border border-border'
+              when 'paid', 'transferred', 'spent' then 'bg-success-soft text-success border border-success-soft'
+              else 'bg-muted text-foreground border border-border'
               end
             %>">
               <%= t("activerecord.attributes.planned_expense.status_options.#{planned_expense.status}") %>
@@ -140,12 +140,12 @@
 
     <!-- Summary Stats -->
     <div class="mt-6 grid grid-cols-1 md:grid-cols-3 gap-4">
-      <div class="bg-blue-50 rounded-lg p-4 border border-blue-200">
-        <p class="text-sm font-medium text-blue-600 mb-1">Total Contributions</p>
-        <p class="text-2xl font-bold text-blue-900"><%= @planned_expenses.count %></p>
+      <div class="bg-muted/35 rounded-lg p-4 border border-border">
+        <p class="text-sm font-medium text-accent mb-1">Total Contributions</p>
+        <p class="text-2xl font-bold text-foreground"><%= @planned_expenses.count %></p>
       </div>
-      <div class="bg-green-50 rounded-lg p-4 border border-green-200">
-        <p class="text-sm font-medium text-green-600 mb-1">Total Amount Saved</p>
+      <div class="bg-green-50 rounded-lg p-4 border border-success-soft">
+        <p class="text-sm font-medium text-success mb-1">Total Amount Saved</p>
         <p class="text-2xl font-bold text-green-900"><%= number_to_currency(@expense_template.total_saved) %></p>
       </div>
       <div class="bg-indigo-50 rounded-lg p-4 border border-indigo-200">
@@ -157,12 +157,12 @@
     </div>
   <% else %>
     <!-- Empty State -->
-    <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
+    <div class="text-center py-12 bg-card rounded-xl border-2 border-dashed border-input">
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
       </svg>
-      <h3 class="mt-2 text-sm font-medium text-gray-900">No planned expenses yet</h3>
-      <p class="mt-1 text-sm text-gray-500">Start using this template in your planned expenses to track progress.</p>
+      <h3 class="mt-2 text-sm font-medium text-foreground">No planned expenses yet</h3>
+      <p class="mt-1 text-sm text-muted-foreground">Start using this template in your planned expenses to track progress.</p>
     </div>
   <% end %>
 </div>

--- a/app/views/expenses/_form.html.erb
+++ b/app/views/expenses/_form.html.erb
@@ -1,7 +1,7 @@
 <% income_events_json = (@income_events || []).map { |ie| { id: ie.id, description: ie.description, expected_amount: ie.expected_amount.to_f, expected_date: ie.expected_date.iso8601 } }.to_json.html_safe %>
 <%= form_with model: [@budget_period, @expense].compact, local: true, class: "space-y-6", data: { controller: "expense-form", expense_form_income_events_value: income_events_json, expense_form_locale_value: I18n.locale.to_s } do |form| %>
   <% if @expense.errors.any? %>
-    <div class="bg-red-50 border-l-4 border-red-500 text-red-700 p-4 rounded mb-6">
+    <div class="bg-danger-soft border-l-4 border-red-500 text-danger p-4 rounded mb-6">
       <div class="flex">
         <div class="flex-shrink-0">
           <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
@@ -9,10 +9,10 @@
           </svg>
         </div>
         <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">
+          <h3 class="text-sm font-medium text-danger">
             <%= pluralize(@expense.errors.count, "error") %> prohibited this expense from being saved:
           </h3>
-          <ul class="mt-2 text-sm text-red-700 list-disc list-inside">
+          <ul class="mt-2 text-sm text-danger list-disc list-inside">
             <% @expense.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -23,9 +23,9 @@
   <% end %>
 
   <!-- Primary Information Section -->
-  <div class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-6 border-2 border-blue-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-      <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  <div class="bg-gradient-to-r from-blue-50 to-indigo-50 rounded-xl p-6 border-2 border-border">
+    <h3 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+      <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
       </svg>
       Información Principal
@@ -34,21 +34,21 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <!-- Amount (First) -->
       <div>
-        <%= form.label :amount, "Monto", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.label :amount, "Monto", class: "block text-sm font-medium text-foreground mb-2" %>
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span class="text-gray-500 sm:text-sm">$</span>
+            <span class="text-muted-foreground sm:text-sm">$</span>
           </div>
-          <%= form.number_field :amount, step: 0.01, class: "block w-full pl-7 rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", placeholder: "0.00" %>
+          <%= form.number_field :amount, step: 0.01, class: "block w-full pl-7 rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", placeholder: "0.00" %>
         </div>
-        <p class="mt-1 text-xs text-gray-500">Cantidad del gasto</p>
+        <p class="mt-1 text-xs text-muted-foreground">Cantidad del gasto</p>
       </div>
 
       <!-- Date (Second) -->
       <div>
-        <%= form.label :date, "Fecha", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.date_field :date, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", data: { expense_form_target: "dateField", action: "change->expense-form#filterByDate" } %>
-        <p class="mt-1 text-xs text-gray-500">Fecha del gasto</p>
+        <%= form.label :date, "Fecha", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.date_field :date, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { expense_form_target: "dateField", action: "change->expense-form#filterByDate" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Fecha del gasto</p>
       </div>
     </div>
 
@@ -60,30 +60,30 @@
     <% destination_options = grouped_options_for_select(account_option_groups, @expense.destination_selection) %>
     <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
       <div>
-        <%= form.label :source_selection, "Source account", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.select :source_selection, source_options, { include_blank: "Select source account" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Choose the account where this expense is charged from.</p>
+        <%= form.label :source_selection, "Source account", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.select :source_selection, source_options, { include_blank: "Select source account" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Choose the account where this expense is charged from.</p>
       </div>
       <div>
-        <%= form.label :destination_selection, "Destination account", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.select :destination_selection, destination_options, { include_blank: "Leave blank for a normal expense" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Use only for transfers or liability payments.</p>
+        <%= form.label :destination_selection, "Destination account", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.select :destination_selection, destination_options, { include_blank: "Leave blank for a normal expense" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Use only for transfers or liability payments.</p>
       </div>
     </div>
 
     <!-- Income Event (Third) - Filtered by Date -->
     <div class="mt-6" data-expense-form-target="incomeEventContainer">
-      <%= form.label :income_event_id, "Evento de ingreso", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= form.collection_select :income_event_id, (@income_events || []), :id, lambda { |ie| "#{ie.description} - #{number_to_currency(ie.expected_amount)} (#{ie.expected_date.strftime('%d %b %Y')})" }, { include_blank: "Ninguno (sin asignar)", selected: @expense.persisted? ? @expense.income_event_id : nil }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", data: { expense_form_target: "incomeEventSelect" } } %>
-      <p class="mt-1 text-xs text-gray-500">Opcional - Se filtrará por mes según la fecha seleccionada</p>
-      <p class="mt-1 text-xs text-blue-600 hidden" data-expense-form-target="message"></p>
+      <%= form.label :income_event_id, "Evento de ingreso", class: "block text-sm font-medium text-foreground mb-2" %>
+      <%= form.collection_select :income_event_id, (@income_events || []), :id, lambda { |ie| "#{ie.description} - #{number_to_currency(ie.expected_amount)} (#{ie.expected_date.strftime('%d %b %Y')})" }, { include_blank: "Ninguno (sin asignar)", selected: @expense.persisted? ? @expense.income_event_id : nil }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { expense_form_target: "incomeEventSelect" } } %>
+      <p class="mt-1 text-xs text-muted-foreground">Opcional - Se filtrará por mes según la fecha seleccionada</p>
+      <p class="mt-1 text-xs text-accent hidden" data-expense-form-target="message"></p>
     </div>
   </div>
 
   <!-- Additional Details Section -->
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-      <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  <div class="bg-card rounded-xl shadow-sm border border-border p-6 space-y-6">
+    <h3 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+      <svg class="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
       </svg>
       Detalles Adicionales
@@ -92,29 +92,29 @@
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <!-- Budget Period -->
       <div>
-        <%= form.label :budget_period_id, "Periodo presupuestario", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.collection_select :budget_period_id, BudgetPeriod.all, :id, :name, { selected: @budget_period&.id || (@expense.persisted? ? @expense.budget_period_id : nil) }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Requerido - Puedes cambiarlo si es necesario</p>
+        <%= form.label :budget_period_id, "Periodo presupuestario", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.collection_select :budget_period_id, BudgetPeriod.all, :id, :name, { selected: @budget_period&.id || (@expense.persisted? ? @expense.budget_period_id : nil) }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Requerido - Puedes cambiarlo si es necesario</p>
       </div>
 
       <!-- Category -->
       <div>
-        <%= form.label :category_id, "Categoría", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.collection_select :category_id, Category.all, :id, :name, { prompt: "Seleccionar categoría" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Categoría del gasto</p>
+        <%= form.label :category_id, "Categoría", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.collection_select :category_id, Category.all, :id, :name, { prompt: "Seleccionar categoría" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Categoría del gasto</p>
       </div>
     </div>
 
     <!-- Description -->
     <div>
-      <%= form.label :description, "Descripción", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= form.text_field :description, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", placeholder: "e.g., Compras, Alquiler, Servicios..." %>
-      <p class="mt-1 text-xs text-gray-500">Breve descripción del gasto</p>
+      <%= form.label :description, "Descripción", class: "block text-sm font-medium text-foreground mb-2" %>
+      <%= form.text_field :description, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", placeholder: "e.g., Compras, Alquiler, Servicios..." %>
+      <p class="mt-1 text-xs text-muted-foreground">Breve descripción del gasto</p>
     </div>
   </div>
 
   <!-- Form Actions -->
-  <div class="flex items-center justify-end gap-4 pt-6 border-t border-gray-200">
+  <div class="flex items-center justify-end gap-4 pt-6 border-t border-border">
     <%= render Ui::ButtonComponent.new(
       href: @budget_period ? @budget_period : expenses_path,
       label: "Cancelar",

--- a/app/views/expenses/edit.html.erb
+++ b/app/views/expenses/edit.html.erb
@@ -2,8 +2,8 @@
   <h1 class="text-2xl font-bold mb-4"><%= t("expenses.edit.title") %></h1>
 
   <% if @expense.budget_period %>
-  <div class="mb-4 p-3 bg-blue-50 border border-blue-200 rounded">
-    <p class="text-sm text-gray-700">
+  <div class="mb-4 p-3 bg-muted/35 border border-border rounded">
+    <p class="text-sm text-foreground">
       <strong>Periodo presupuestario actual:</strong> <%= @expense.budget_period.name %>
     </p>
   </div>
@@ -11,18 +11,18 @@
 
 <% if @expense.income_event %>
   <div class="mb-4 p-3 bg-purple-50 border border-purple-200 rounded">
-    <p class="text-sm text-gray-700">
+    <p class="text-sm text-foreground">
       <strong>Evento de ingreso actual:</strong> <%= @expense.income_event.description %> - <%= number_to_currency(@expense.income_event.expected_amount) %>
     </p>
   </div>
 <% end %>
 
 <% if @expense.planned_expense %>
-  <div class="mb-4 p-3 bg-green-50 border border-green-200 rounded">
-    <p class="text-sm text-gray-700">
+  <div class="mb-4 p-3 bg-green-50 border border-success-soft rounded">
+    <p class="text-sm text-foreground">
       <strong>Gasto planificado relacionado:</strong> <%= @expense.planned_expense.description %> - <%= number_to_currency(@expense.planned_expense.amount) %>
     </p>
-    <p class="text-xs text-gray-600 mt-1">
+    <p class="text-xs text-muted-foreground mt-1">
       Si cambias el evento de ingreso, el gasto planificado también se actualizará automáticamente.
     </p>
   </div>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -9,22 +9,22 @@
 
   <%= form_with url: expenses_path, method: :get, local: true, class: "flex flex-col sm:flex-row sm:items-end gap-4 flex-wrap mb-4" do |f| %>
     <div class="flex flex-wrap items-center gap-2">
-      <label for="date_from" class="text-sm font-medium text-gray-700"><%= t("expenses.index.date_from") %></label>
-      <%= f.date_field :date_from, value: params[:date_from], id: "date_from", class: "rounded border border-gray-300 px-3 py-2 text-sm" %>
+      <label for="date_from" class="text-sm font-medium text-foreground"><%= t("expenses.index.date_from") %></label>
+      <%= f.date_field :date_from, value: params[:date_from], id: "date_from", class: "rounded border border-input px-3 py-2 text-sm" %>
     </div>
     <div class="flex flex-wrap items-center gap-2">
-      <label for="date_to" class="text-sm font-medium text-gray-700"><%= t("expenses.index.date_to") %></label>
-      <%= f.date_field :date_to, value: params[:date_to], id: "date_to", class: "rounded border border-gray-300 px-3 py-2 text-sm" %>
+      <label for="date_to" class="text-sm font-medium text-foreground"><%= t("expenses.index.date_to") %></label>
+      <%= f.date_field :date_to, value: params[:date_to], id: "date_to", class: "rounded border border-input px-3 py-2 text-sm" %>
     </div>
     <div class="flex flex-wrap items-center gap-2">
-      <label for="category_id" class="text-sm font-medium text-gray-700"><%= t("expenses.index.category") %></label>
-      <%= f.select :category_id, Category.all.pluck(:name, :id), { include_blank: t("expenses.index.all_categories") }, id: "category_id", class: "rounded border border-gray-300 px-3 py-2 text-sm" %>
+      <label for="category_id" class="text-sm font-medium text-foreground"><%= t("expenses.index.category") %></label>
+      <%= f.select :category_id, Category.all.pluck(:name, :id), { include_blank: t("expenses.index.all_categories") }, id: "category_id", class: "rounded border border-input px-3 py-2 text-sm" %>
     </div>
     <div class="flex flex-wrap items-center gap-2 flex-grow min-w-0">
-      <label for="q" class="text-sm font-medium text-gray-700 sr-only"><%= t("expenses.index.description_placeholder") %></label>
-      <%= f.text_field :q, placeholder: t("expenses.index.description_placeholder"), value: params[:q], id: "q", class: "rounded border border-gray-300 px-3 py-2 text-sm flex-1 min-w-0" %>
+      <label for="q" class="text-sm font-medium text-foreground sr-only"><%= t("expenses.index.description_placeholder") %></label>
+      <%= f.text_field :q, placeholder: t("expenses.index.description_placeholder"), value: params[:q], id: "q", class: "rounded border border-input px-3 py-2 text-sm flex-1 min-w-0" %>
     </div>
-    <%= f.submit t("expenses.index.filter"), class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm font-medium cursor-pointer w-full sm:w-auto" %>
+    <%= f.submit t("expenses.index.filter"), class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary text-sm font-medium cursor-pointer w-full sm:w-auto" %>
   <% end %>
 
   <div class="mb-4 flex justify-between items-center">
@@ -39,9 +39,9 @@
 
   <%# Desktop: table %>
   <div class="hidden md:block overflow-x-auto">
-    <table class="min-w-full bg-white border">
+    <table class="ui-table">
       <thead>
-        <tr class="bg-gray-100">
+        <tr class="bg-muted">
           <th class="px-4 py-2 text-left"><%= t("expenses.index.date") %></th>
           <th class="px-4 py-2 text-left"><%= t("expenses.index.category") %></th>
           <th class="px-4 py-2 text-left"><%= t("expenses.index.description") %></th>
@@ -59,7 +59,7 @@
             <td class="px-4 py-2"><%= expense.description %></td>
             <td class="px-4 py-2">
               <% if expense.budget_period %>
-                <%= link_to expense.budget_period.name, expense.budget_period, class: "text-blue-600 hover:underline" %>
+                <%= link_to expense.budget_period.name, expense.budget_period, class: "text-accent hover:underline hover:text-accent-dark" %>
               <% else %>
                 <span class="text-gray-400"><%= t("expenses.index.unassigned") %></span>
               <% end %>
@@ -74,15 +74,15 @@
             <td class="px-4 py-2 text-right"><%= number_to_currency(expense.amount) %></td>
             <td class="px-4 py-2 text-center">
               <span class="inline-flex items-center gap-2">
-                <%= link_to t("shared.edit"), edit_expense_path(expense), class: "px-3 py-2 text-sm text-blue-600 hover:underline rounded hover:bg-blue-50 min-h-[44px] inline-flex items-center", aria: { label: "#{t('shared.edit')} #{t('expenses.index.title')}" } %>
-                <%= link_to t("shared.delete"), expense, data: { turbo_method: :delete, turbo_confirm: t("expenses.index.confirm_destroy") }, class: "px-3 py-2 text-sm text-red-600 hover:underline rounded hover:bg-red-50 min-h-[44px] inline-flex items-center", aria: { label: "#{t('shared.delete')} #{t('expenses.index.title')}" } %>
+                <%= link_to t("shared.edit"), edit_expense_path(expense), class: "px-3 py-2 text-sm text-accent hover:underline rounded hover:bg-muted/35 min-h-[44px] inline-flex items-center", aria: { label: "#{t('shared.edit')} #{t('expenses.index.title')}" } %>
+                <%= link_to t("shared.delete"), expense, data: { turbo_method: :delete, turbo_confirm: t("expenses.index.confirm_destroy") }, class: "px-3 py-2 text-sm text-danger hover:underline rounded hover:bg-danger-soft min-h-[44px] inline-flex items-center", aria: { label: "#{t('shared.delete')} #{t('expenses.index.title')}" } %>
               </span>
             </td>
           </tr>
         <% end %>
       </tbody>
       <tfoot>
-        <tr class="bg-gray-50 font-semibold">
+        <tr class="bg-muted/35 font-semibold">
           <td colspan="5" class="px-4 py-2 text-right">Total:</td>
           <td class="px-4 py-2 text-right">
             <%= number_to_currency(@expenses.sum(:amount)) %>
@@ -96,28 +96,28 @@
   <%# Mobile: card list %>
   <div class="md:hidden space-y-3">
     <% ordered_expenses.each do |expense| %>
-      <div class="bg-white border rounded-lg p-4 shadow-sm">
+      <div class="bg-card border rounded-lg p-4 shadow-sm">
         <div class="flex justify-between items-start gap-2 mb-2">
-          <span class="font-semibold text-gray-900 truncate flex-1"><%= expense.description.presence || expense.category.name %></span>
-          <span class="font-semibold text-gray-900 whitespace-nowrap"><%= number_to_currency(expense.amount) %></span>
+          <span class="font-semibold text-foreground truncate flex-1"><%= expense.description.presence || expense.category.name %></span>
+          <span class="font-semibold text-foreground whitespace-nowrap"><%= number_to_currency(expense.amount) %></span>
         </div>
-        <div class="text-sm text-gray-600 mb-1">
+        <div class="text-sm text-muted-foreground mb-1">
           <%= expense.date.strftime("%d %b %Y") %> · <%= expense.category.name %>
         </div>
-        <div class="text-xs text-gray-500 mb-3">
+        <div class="text-xs text-muted-foreground mb-3">
           <%= t("expenses.index.budget_period") %>: <%= expense.budget_period ? expense.budget_period.name : t("expenses.index.unassigned") %> ·
           <%= t("expenses.index.income_event") %>: <%= expense.income_event ? expense.income_event.description : t("expenses.index.unassigned") %>
         </div>
         <div class="flex flex-wrap gap-2">
-          <%= link_to t("shared.edit"), edit_expense_path(expense), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm font-medium text-blue-600 bg-blue-50 rounded hover:bg-blue-100", aria: { label: "#{t('shared.edit')} #{t('expenses.index.title')}" } %>
-          <%= link_to t("shared.delete"), expense, data: { turbo_method: :delete, turbo_confirm: t("expenses.index.confirm_destroy") }, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm font-medium text-red-600 bg-red-50 rounded hover:bg-red-100", aria: { label: "#{t('shared.delete')} #{t('expenses.index.title')}" } %>
-          <%= link_to t("shared.view"), expense, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm font-medium text-gray-600 bg-gray-100 rounded hover:bg-gray-200", aria: { label: "#{t('shared.view')} #{t('expenses.index.title')}" } %>
+          <%= link_to t("shared.edit"), edit_expense_path(expense), class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm font-medium text-accent bg-muted/35 rounded hover:bg-muted", aria: { label: "#{t('shared.edit')} #{t('expenses.index.title')}" } %>
+          <%= link_to t("shared.delete"), expense, data: { turbo_method: :delete, turbo_confirm: t("expenses.index.confirm_destroy") }, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm font-medium text-danger bg-danger-soft rounded hover:bg-danger-soft", aria: { label: "#{t('shared.delete')} #{t('expenses.index.title')}" } %>
+          <%= link_to t("shared.view"), expense, class: "inline-flex items-center justify-center min-h-[44px] px-4 py-2 text-sm font-medium text-muted-foreground bg-muted rounded hover:bg-muted", aria: { label: "#{t('shared.view')} #{t('expenses.index.title')}" } %>
         </div>
       </div>
     <% end %>
 
     <% if ordered_expenses.any? %>
-      <div class="bg-gray-50 border rounded-lg p-4 font-semibold flex justify-between items-center">
+      <div class="bg-muted/35 border rounded-lg p-4 font-semibold flex justify-between items-center">
         <span><%= t("expenses.index.total") %>:</span>
         <span><%= number_to_currency(@expenses.sum(:amount)) %></span>
       </div>

--- a/app/views/expenses/quick_new.html.erb
+++ b/app/views/expenses/quick_new.html.erb
@@ -1,14 +1,14 @@
 <div class="container mx-auto px-4 py-4">
   <h1 class="text-2xl font-bold mb-2"><%= t("expenses.quick_new.title") %></h1>
-  <p class="text-sm text-gray-600 mb-6"><%= t("expenses.quick_new.subtitle") %></p>
+  <p class="text-sm text-muted-foreground mb-6"><%= t("expenses.quick_new.subtitle") %></p>
 
   <%= form_with model: @expense, url: income_event_direct_expenses_path(@income_event), local: true, class: "space-y-6" do |form| %>
     <% if @expense.errors.any? %>
-      <div class="bg-red-50 border-l-4 border-red-500 text-red-700 p-4 rounded">
-        <h3 class="text-sm font-medium text-red-800 mb-2">
+      <div class="bg-danger-soft border-l-4 border-red-500 text-danger p-4 rounded">
+        <h3 class="text-sm font-medium text-danger mb-2">
           <%= pluralize(@expense.errors.count, "error") %> prohibited this expense from being saved:
         </h3>
-        <ul class="text-sm text-red-700 list-disc list-inside">
+        <ul class="text-sm text-danger list-disc list-inside">
           <% @expense.errors.full_messages.each do |message| %>
             <li><%= message %></li>
           <% end %>
@@ -16,37 +16,37 @@
       </div>
     <% end %>
 
-    <div class="bg-blue-50 border border-blue-200 rounded-lg p-4">
-      <p class="text-xs font-medium uppercase tracking-wide text-blue-700 mb-1"><%= t("expenses.quick_new.income_event") %></p>
-      <p class="text-base font-semibold text-gray-900"><%= @income_event.description %></p>
-      <p class="text-sm text-gray-600"><%= number_to_currency(@income_event.expected_amount) %> - <%= @income_event.expected_date.strftime("%d %b %Y") %></p>
+    <div class="bg-muted/35 border border-border rounded-lg p-4">
+      <p class="text-xs font-medium uppercase tracking-wide text-accent mb-1"><%= t("expenses.quick_new.income_event") %></p>
+      <p class="text-base font-semibold text-foreground"><%= @income_event.description %></p>
+      <p class="text-sm text-muted-foreground"><%= number_to_currency(@income_event.expected_amount) %> - <%= @income_event.expected_date.strftime("%d %b %Y") %></p>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div>
-        <%= form.label :amount, t("expenses.quick_new.amount"), class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.number_field :amount, step: 0.01, required: true, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", placeholder: "0.00" %>
+        <%= form.label :amount, t("expenses.quick_new.amount"), class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.number_field :amount, step: 0.01, required: true, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", placeholder: "0.00" %>
       </div>
 
       <div>
-        <%= form.label :date, t("expenses.quick_new.date"), class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.date_field :date, required: true, value: (@expense.date || Date.current), class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" %>
+        <%= form.label :date, t("expenses.quick_new.date"), class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.date_field :date, required: true, value: (@expense.date || Date.current), class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" %>
       </div>
 
       <div>
-        <%= form.label :category_id, t("expenses.quick_new.category"), class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.collection_select :category_id, @categories, :id, :name, { prompt: t("expenses.quick_new.select_category") }, { required: true, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
+        <%= form.label :category_id, t("expenses.quick_new.category"), class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.collection_select :category_id, @categories, :id, :name, { prompt: t("expenses.quick_new.select_category") }, { required: true, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
       </div>
 
       <div>
-        <%= form.label :budget_period_id, t("expenses.quick_new.budget_period"), class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.collection_select :budget_period_id, @budget_periods, :id, :name, { prompt: t("expenses.quick_new.select_budget_period"), selected: @expense.budget_period_id }, { required: true, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
+        <%= form.label :budget_period_id, t("expenses.quick_new.budget_period"), class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.collection_select :budget_period_id, @budget_periods, :id, :name, { prompt: t("expenses.quick_new.select_budget_period"), selected: @expense.budget_period_id }, { required: true, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
       </div>
     </div>
 
     <div>
-      <%= form.label :description, t("expenses.quick_new.description"), class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= form.text_field :description, required: true, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500", placeholder: t("expenses.quick_new.description_placeholder") %>
+      <%= form.label :description, t("expenses.quick_new.description"), class: "block text-sm font-medium text-foreground mb-2" %>
+      <%= form.text_field :description, required: true, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", placeholder: t("expenses.quick_new.description_placeholder") %>
     </div>
 
     <% account_option_groups = {
@@ -57,17 +57,17 @@
     <% destination_options = grouped_options_for_select(account_option_groups, @expense.destination_selection) %>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div>
-        <%= form.label :source_selection, "Source account", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.select :source_selection, source_options, { include_blank: "Select source account" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
+        <%= form.label :source_selection, "Source account", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.select :source_selection, source_options, { include_blank: "Select source account" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
       </div>
       <div>
-        <%= form.label :destination_selection, "Destination account", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.select :destination_selection, destination_options, { include_blank: "Leave blank for a normal expense" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" } %>
+        <%= form.label :destination_selection, "Destination account", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.select :destination_selection, destination_options, { include_blank: "Leave blank for a normal expense" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
       </div>
     </div>
 
     <div class="flex items-center justify-end gap-4 pt-2">
-      <%= link_to t("expenses.quick_new.cancel"), @income_event, class: "px-4 py-2 rounded-lg bg-gray-100 text-gray-700 hover:bg-gray-200" %>
+      <%= link_to t("expenses.quick_new.cancel"), @income_event, class: "px-4 py-2 rounded-lg bg-muted text-foreground hover:bg-muted" %>
       <%= form.submit t("expenses.quick_new.save"), class: "px-6 py-2 bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg shadow-md hover:shadow-lg hover:from-blue-700 hover:to-blue-800 transition-all duration-200 font-medium" %>
     </div>
   <% end %>

--- a/app/views/expenses/show.html.erb
+++ b/app/views/expenses/show.html.erb
@@ -3,56 +3,56 @@
 <div class="container mx-auto px-4 py-4">
   <h1 class="text-2xl font-bold mb-4"><%= t("expenses.show.title") %></h1>
 
-  <div class="bg-white border rounded-lg p-6 mb-4">
+  <div class="bg-card border rounded-lg p-6 mb-4">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
       <div>
-        <p class="text-sm text-gray-600"><%= t("expenses.form.date") %></p>
+        <p class="text-sm text-muted-foreground"><%= t("expenses.form.date") %></p>
         <p class="font-semibold"><%= @expense.date.strftime("%d %b %Y") %></p>
       </div>
       <div>
-        <p class="text-sm text-gray-600"><%= t("expenses.form.amount") %></p>
+        <p class="text-sm text-muted-foreground"><%= t("expenses.form.amount") %></p>
         <p class="font-semibold text-lg"><%= number_to_currency(@expense.amount) %></p>
       </div>
       <div>
-        <p class="text-sm text-gray-600"><%= t("expenses.form.category") %></p>
+        <p class="text-sm text-muted-foreground"><%= t("expenses.form.category") %></p>
         <p class="font-semibold"><%= @expense.category.name %></p>
       </div>
       <div>
-        <p class="text-sm text-gray-600"><%= t("expenses.index.description") %></p>
+        <p class="text-sm text-muted-foreground"><%= t("expenses.index.description") %></p>
         <p class="font-semibold"><%= @expense.description %></p>
       </div>
     </div>
 
     <div class="mt-4 pt-4 border-t">
       <div class="mb-3">
-        <p class="text-sm text-gray-600 mb-1"><%= t("expenses.index.budget_period") %></p>
+        <p class="text-sm text-muted-foreground mb-1"><%= t("expenses.index.budget_period") %></p>
         <% if @expense.budget_period %>
-          <%= link_to @expense.budget_period, class: "inline-flex items-center px-3 py-1 rounded-full bg-blue-100 text-blue-800 hover:bg-blue-200" do %>
+          <%= link_to @expense.budget_period, class: "inline-flex items-center px-3 py-1 rounded-full bg-muted text-foreground hover:bg-blue-200" do %>
             <%= @expense.budget_period.name %>
           <% end %>
         <% else %>
-          <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-800"><%= t("expenses.index.unassigned") %></span>
+          <span class="inline-flex items-center px-3 py-1 rounded-full bg-muted text-foreground"><%= t("expenses.index.unassigned") %></span>
         <% end %>
       </div>
 
       <div class="mb-3">
-        <p class="text-sm text-gray-600 mb-1"><%= t("expenses.index.income_event") %></p>
+        <p class="text-sm text-muted-foreground mb-1"><%= t("expenses.index.income_event") %></p>
         <% if @expense.income_event %>
           <%= link_to @expense.income_event, class: "inline-flex items-center px-3 py-1 rounded-full bg-purple-100 text-purple-800 hover:bg-purple-200" do %>
             <%= @expense.income_event.description %> - <%= number_to_currency(@expense.income_event.expected_amount) %>
           <% end %>
         <% else %>
-          <span class="inline-flex items-center px-3 py-1 rounded-full bg-gray-100 text-gray-800"><%= t("expenses.index.unassigned") %></span>
+          <span class="inline-flex items-center px-3 py-1 rounded-full bg-muted text-foreground"><%= t("expenses.index.unassigned") %></span>
         <% end %>
       </div>
 
       <% if @expense.planned_expense %>
         <div>
-          <p class="text-sm text-gray-600 mb-1"><%= t("expenses.show.planned_expense") %></p>
-          <%= link_to income_event_planned_expense_path(@expense.planned_expense.income_event, @expense.planned_expense), class: "inline-flex items-center px-3 py-1 rounded-full bg-green-100 text-green-800 hover:bg-green-200" do %>
+          <p class="text-sm text-muted-foreground mb-1"><%= t("expenses.show.planned_expense") %></p>
+          <%= link_to income_event_planned_expense_path(@expense.planned_expense.income_event, @expense.planned_expense), class: "inline-flex items-center px-3 py-1 rounded-full bg-success-soft text-success hover:bg-green-200" do %>
             <%= @expense.planned_expense.description %> - <%= number_to_currency(@expense.planned_expense.amount) %>
           <% end %>
-          <p class="mt-1 text-xs text-gray-500"><%= t("expenses.show.planned_expense_note") %></p>
+          <p class="mt-1 text-xs text-muted-foreground"><%= t("expenses.show.planned_expense_note") %></p>
         </div>
       <% end %>
     </div>

--- a/app/views/finance/index.html.erb
+++ b/app/views/finance/index.html.erb
@@ -1,9 +1,9 @@
 <div class="container mx-auto px-4 py-6 space-y-8">
-  <section class="rounded-3xl bg-gradient-to-r from-slate-900 via-slate-800 to-slate-700 text-white p-8 shadow-xl">
+  <section class="rounded-3xl border border-border bg-[linear-gradient(135deg,color-mix(in_oklab,hsl(var(--card))_90%,hsl(var(--background))_10%),hsl(var(--card)))] text-foreground p-8 shadow-sm">
     <div class="max-w-3xl space-y-4">
-      <p class="text-sm uppercase tracking-[0.2em] text-slate-300">Finance hub</p>
+      <p class="text-sm uppercase tracking-[0.16em] text-muted-foreground">Finance hub</p>
       <h1 class="text-3xl font-bold">How money moves in Open Budget</h1>
-      <p class="text-slate-200 text-lg leading-7">
+      <p class="text-muted-foreground text-lg leading-7">
         Income events are still your planning layer. Financial accounts and liabilities are the real balances.
         Planned expenses and loan payments show what you intend to execute, while financial entries record what actually moved.
       </p>
@@ -11,40 +11,40 @@
   </section>
 
   <section class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
-    <div class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <p class="text-sm text-gray-500">Categories</p>
-      <p class="mt-2 text-3xl font-bold text-gray-900"><%= @category_count %></p>
-      <p class="mt-2 text-sm text-gray-600">Used by expenses, planned expenses, and entries.</p>
-      <%= link_to "Manage categories", finance_categories_path, class: "mt-4 inline-block text-blue-600 hover:underline" %>
+    <div class="rounded-2xl border border-border bg-card p-5 shadow-sm border-t-4 border-t-primary">
+      <p class="text-sm text-muted-foreground">Categories</p>
+      <p class="mt-2 text-3xl font-bold text-foreground"><%= @category_count %></p>
+      <p class="mt-2 text-sm text-muted-foreground">Used by expenses, planned expenses, and entries.</p>
+      <%= link_to "Manage categories", finance_categories_path, class: "mt-4 inline-block text-accent hover:underline hover:text-accent-dark" %>
     </div>
 
-    <div class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <p class="text-sm text-gray-500">Assets accounts</p>
-      <p class="mt-2 text-3xl font-bold text-gray-900"><%= @financial_account_count %></p>
-      <p class="mt-2 text-sm text-gray-600">Debit, checking, or savings accounts that hold cash.</p>
-      <%= link_to "Manage assets", finance_financial_accounts_path, class: "mt-4 inline-block text-blue-600 hover:underline" %>
+    <div class="rounded-2xl border border-border bg-card p-5 shadow-sm border-t-4 border-t-warning">
+      <p class="text-sm text-muted-foreground">Assets accounts</p>
+      <p class="mt-2 text-3xl font-bold text-foreground"><%= @financial_account_count %></p>
+      <p class="mt-2 text-sm text-muted-foreground">Debit, checking, or savings accounts that hold cash.</p>
+      <%= link_to "Manage assets", finance_financial_accounts_path, class: "mt-4 inline-block text-accent hover:underline hover:text-accent-dark" %>
     </div>
 
-    <div class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <p class="text-sm text-gray-500">Liability Accounts</p>
-      <p class="mt-2 text-3xl font-bold text-gray-900"><%= @financial_liability_count %></p>
-      <p class="mt-2 text-sm text-gray-600">Credit cards and personal credits you want to pay down.
+    <div class="rounded-2xl border border-border bg-card p-5 shadow-sm border-t-4 border-t-secondary-accent">
+      <p class="text-sm text-muted-foreground">Liability Accounts</p>
+      <p class="mt-2 text-3xl font-bold text-foreground"><%= @financial_liability_count %></p>
+      <p class="mt-2 text-sm text-muted-foreground">Credit cards and personal credits you want to pay down.
       </p>
-      <%= link_to "Manage liabilities", finance_financial_liabilities_path, class: "mt-4 inline-block text-blue-600 hover:underline" %>
+      <%= link_to "Manage liabilities", finance_financial_liabilities_path, class: "mt-4 inline-block text-accent hover:underline hover:text-accent-dark" %>
     </div>
 
-    <div class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <p class="text-sm text-gray-500">Entries</p>
-      <p class="mt-2 text-3xl font-bold text-gray-900"><%= @financial_entry_count %></p>
-      <p class="mt-2 text-sm text-gray-600">The audit trail for actual money movements.</p>
-      <%= link_to "View entries", finance_financial_entries_path, class: "mt-4 inline-block text-blue-600 hover:underline" %>
+    <div class="rounded-2xl border border-border bg-card p-5 shadow-sm border-t-4 border-t-success">
+      <p class="text-sm text-muted-foreground">Entries</p>
+      <p class="mt-2 text-3xl font-bold text-foreground"><%= @financial_entry_count %></p>
+      <p class="mt-2 text-sm text-muted-foreground">The audit trail for actual money movements.</p>
+      <%= link_to "View entries", finance_financial_entries_path, class: "mt-4 inline-block text-accent hover:underline hover:text-accent-dark" %>
     </div>
   </section>
 
   <section class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-4">
-      <h2 class="text-xl font-semibold text-gray-900">Flow model</h2>
-      <div class="space-y-3 text-sm leading-6 text-gray-700">
+    <div class="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4">
+      <h2 class="text-xl font-semibold text-foreground">Flow model</h2>
+      <div class="space-y-3 text-sm leading-6 text-foreground">
         <p><strong>1. IncomeEvent</strong> is where you plan or register income.</p>
         <p><strong>2. PlannedExpense</strong> is what you intend to spend from that income.</p>
         <p><strong>3. LoanPaymentSchedule</strong> is a planned debt payment, shown like a checklist item.</p>
@@ -54,9 +54,9 @@
       </div>
     </div>
 
-    <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-4">
-      <h2 class="text-xl font-semibold text-gray-900">Recommended daily workflow</h2>
-      <ol class="list-decimal list-inside space-y-2 text-sm leading-6 text-gray-700">
+    <div class="rounded-2xl border border-secondary-accent-soft bg-secondary-accent-soft p-6 shadow-sm space-y-4">
+      <h2 class="text-xl font-semibold text-foreground">Recommended daily workflow</h2>
+      <ol class="list-decimal list-inside space-y-2 text-sm leading-6 text-foreground">
         <li>Create or open an income event like salary.</li>
         <li>Plan your normal expenses and check the loan payments you want to cover.</li>
         <li>Open the loan or the income event and mark a payment as paid when you actually send it.</li>
@@ -66,9 +66,9 @@
     </div>
   </section>
 
-  <section class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm space-y-4">
-    <h2 class="text-xl font-semibold text-gray-900">Why this is separate from Settings</h2>
-    <p class="text-sm leading-6 text-gray-700">
+  <section class="rounded-2xl border border-border bg-card p-6 shadow-sm space-y-4">
+    <h2 class="text-xl font-semibold text-foreground">Why this is separate from Settings</h2>
+    <p class="text-sm leading-6 text-foreground">
       Settings are for user preferences and app configuration. Finance is an operating area: balances, debts, payments,
       and execution. Keeping them separate reduces confusion and makes the model easier to understand.
     </p>

--- a/app/views/financial/accounts/_form.html.erb
+++ b/app/views/financial/accounts/_form.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_with model: @financial_account, url: form_url, method: form_method, local: true do |form| %>
   <% if @financial_account.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@financial_account.errors.count, "error") %> prohibited this record from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @financial_account.errors.full_messages.each do |message| %>
@@ -14,32 +14,32 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :account_type, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :account_type, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :account_type, Financial::Asset::ACCOUNT_TYPES.map { |type| [type.humanize, type] }, {}, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :status, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :status, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :status, Financial::Asset::STATUSES.map { |status| [status.humanize, status] }, {}, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :opening_balance, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :opening_balance, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :opening_balance, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", @financial_account.persisted? ? finance_financial_account_path(@financial_account) : finance_financial_accounts_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to "Cancel", @financial_account.persisted? ? finance_financial_account_path(@financial_account) : finance_financial_accounts_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>

--- a/app/views/financial/accounts/index.html.erb
+++ b/app/views/financial/accounts/index.html.erb
@@ -10,9 +10,9 @@
   ) %>
 </div>
 
-<table class="min-w-full bg-white border">
+<table class="ui-table">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left">Name</th>
       <th class="px-4 py-2 text-left">Type</th>
       <th class="px-4 py-2 text-left">Status</th>
@@ -28,9 +28,9 @@
         <td class="px-4 py-2"><%= financial_account.status.humanize %></td>
         <td class="px-4 py-2"><%= number_to_currency(financial_account.current_balance) %></td>
         <td class="px-4 py-2">
-          <%= link_to "View", finance_financial_account_path(financial_account), class: "text-blue-500 hover:underline" %>
-          <%= link_to "Edit", edit_finance_financial_account_path(financial_account), class: "text-blue-500 hover:underline ml-2" %>
-          <%= link_to "Delete", finance_financial_account_path(financial_account), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-red-500 hover:underline ml-2" %>
+          <%= link_to "View", finance_financial_account_path(financial_account), class: "text-accent hover:underline" %>
+          <%= link_to "Edit", edit_finance_financial_account_path(financial_account), class: "text-accent hover:underline ml-2" %>
+          <%= link_to "Delete", finance_financial_account_path(financial_account), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-danger hover:underline ml-2" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/financial/accounts/show.html.erb
+++ b/app/views/financial/accounts/show.html.erb
@@ -1,26 +1,26 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← Back", finance_financial_accounts_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← Back", finance_financial_accounts_path, class: "text-accent hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @financial_account.name %></h1>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Type</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Type</p>
     <p class="font-semibold"><%= @financial_account.account_type.humanize %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Status</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Status</p>
     <p class="font-semibold"><%= @financial_account.status.humanize %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Opening Balance</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Opening Balance</p>
     <p class="font-semibold"><%= number_to_currency(@financial_account.opening_balance) %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Current Balance</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Current Balance</p>
     <p class="font-semibold"><%= number_to_currency(@financial_account.current_balance) %></p>
   </div>
 </div>

--- a/app/views/financial/entries/_form.html.erb
+++ b/app/views/financial/entries/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @financial_entry, url: finance_financial_entries_path, local: true do |form| %>
   <% if @financial_entry.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@financial_entry.errors.count, "error") %> prohibited this record from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @financial_entry.errors.full_messages.each do |message| %>
@@ -11,57 +11,57 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :entry_type, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :entry_type, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :entry_type, Financial::Entry::ENTRY_TYPES.map { |type| [type.humanize, type] }, {}, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :entry_date, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :entry_date, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.date_field :entry_date, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :amount, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :amount, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :amount, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :description, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :description, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :financial_account_id, "Source Account", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :financial_account_id, "Source Account", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :financial_account_id, @financial_accounts, :id, :name, { include_blank: true }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :counterparty_financial_account_id, "Destination Account", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :counterparty_financial_account_id, "Destination Account", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :counterparty_financial_account_id, @financial_accounts, :id, :name, { include_blank: true }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :financial_liability_id, "Liability", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :financial_liability_id, "Liability", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :financial_liability_id, @financial_liabilities, :id, :name, { include_blank: true }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :income_event_id, "Income Event (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :income_event_id, "Income Event (optional)", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :income_event_id, @income_events, :id, :description, { include_blank: true }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :expense_id, "Expense (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :expense_id, "Expense (optional)", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :expense_id, @expenses, :id, :description, { include_blank: true }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", finance_financial_entries_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to "Cancel", finance_financial_entries_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>

--- a/app/views/financial/entries/index.html.erb
+++ b/app/views/financial/entries/index.html.erb
@@ -10,9 +10,9 @@
   ) %>
 </div>
 
-<table class="min-w-full bg-white border">
+<table class="ui-table">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left">Date</th>
       <th class="px-4 py-2 text-left">Type</th>
       <th class="px-4 py-2 text-left">Description</th>
@@ -28,8 +28,8 @@
         <td class="px-4 py-2"><%= financial_entry.description %></td>
         <td class="px-4 py-2"><%= number_to_currency(financial_entry.amount) %></td>
         <td class="px-4 py-2">
-          <%= link_to "View", finance_financial_entry_path(financial_entry), class: "text-blue-500 hover:underline" %>
-          <%= link_to "Delete", finance_financial_entry_path(financial_entry), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-red-500 hover:underline ml-2" %>
+          <%= link_to "View", finance_financial_entry_path(financial_entry), class: "text-accent hover:underline" %>
+          <%= link_to "Delete", finance_financial_entry_path(financial_entry), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-danger hover:underline ml-2" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/financial/entries/show.html.erb
+++ b/app/views/financial/entries/show.html.erb
@@ -1,26 +1,26 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← Back", finance_financial_entries_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← Back", finance_financial_entries_path, class: "text-accent hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @financial_entry.description %></h1>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Type</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Type</p>
     <p class="font-semibold"><%= @financial_entry.entry_type.humanize %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Date</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Date</p>
     <p class="font-semibold"><%= @financial_entry.entry_date %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Amount</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Amount</p>
     <p class="font-semibold"><%= number_to_currency(@financial_entry.amount) %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Account Effect</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Account Effect</p>
     <p class="font-semibold"><%= number_to_currency(@financial_entry.account_delta) %></p>
   </div>
 </div>

--- a/app/views/financial/liabilities/_form.html.erb
+++ b/app/views/financial/liabilities/_form.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_with model: @financial_liability, url: form_url, method: form_method, local: true do |form| %>
   <% if @financial_liability.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@financial_liability.errors.count, "error") %> prohibited this record from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @financial_liability.errors.full_messages.each do |message| %>
@@ -14,37 +14,37 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :liability_type, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :liability_type, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :liability_type, Financial::Liability::LIABILITY_TYPES.map { |type| [type.humanize, type] }, {}, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :status, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :status, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :status, Financial::Liability::STATUSES.map { |status| [status.humanize, status] }, {}, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :opening_balance, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :opening_balance, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :opening_balance, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :credit_limit, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :credit_limit, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :credit_limit, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", @financial_liability.persisted? ? finance_financial_liability_path(@financial_liability) : finance_financial_liabilities_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to "Cancel", @financial_liability.persisted? ? finance_financial_liability_path(@financial_liability) : finance_financial_liabilities_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>

--- a/app/views/financial/liabilities/charge.html.erb
+++ b/app/views/financial/liabilities/charge.html.erb
@@ -1,10 +1,10 @@
 <h1 class="text-2xl font-bold mb-4">Record Card Charge</h1>
 
 <% if flash[:alert].present? %>
-  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700"><%= flash[:alert] %></div>
+  <div class="mb-4 rounded border border-danger-soft bg-danger-soft px-4 py-3 text-danger"><%= flash[:alert] %></div>
 <% end %>
 
-<p class="mb-4 text-sm text-gray-600">
+<p class="mb-4 text-sm text-muted-foreground">
   Liability: <strong><%= @financial_liability.name %></strong>
   (Current owed: <%= number_to_currency(@financial_liability.current_balance) %>)
 </p>
@@ -12,38 +12,38 @@
 <%= form_with url: record_charge_finance_financial_liability_path(@financial_liability), method: :post, local: true do |form| %>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div>
-      <%= label_tag "financial_liability_charge[amount]", "Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_charge[amount]", "Amount", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= number_field_tag "financial_liability_charge[amount]", nil, step: 0.01, min: 0.01, class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div>
-      <%= label_tag "financial_liability_charge[entry_date]", "Date", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_charge[entry_date]", "Date", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= date_field_tag "financial_liability_charge[entry_date]", Date.current, class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div class="md:col-span-2">
-      <%= label_tag "financial_liability_charge[description]", "Description", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_charge[description]", "Description", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= text_field_tag "financial_liability_charge[description]", nil, placeholder: "Coca Cola", class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div>
-      <%= label_tag "financial_liability_charge[category_id]", "Category", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_charge[category_id]", "Category", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= select_tag "financial_liability_charge[category_id]", options_from_collection_for_select(@categories, :id, :name), include_blank: "Select category", class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div>
-      <%= label_tag "financial_liability_charge[budget_period_id]", "Budget period", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_charge[budget_period_id]", "Budget period", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= select_tag "financial_liability_charge[budget_period_id]", options_from_collection_for_select(@budget_periods, :id, :name), include_blank: "Select period", class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div class="md:col-span-2">
-      <%= label_tag "financial_liability_charge[income_event_id]", "Income event (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_charge[income_event_id]", "Income event (optional)", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= select_tag "financial_liability_charge[income_event_id]", options_from_collection_for_select(@income_events, :id, :description), include_blank: "None", class: "border rounded px-3 py-2 w-full" %>
     </div>
   </div>
 
   <div class="mt-6 flex gap-2">
-    <%= submit_tag "Record charge", class: "px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700", data: { turbo_confirm: "Record this liability charge? Please verify amount, date, and category before continuing." } %>
-    <%= link_to "Cancel", finance_financial_liability_path(@financial_liability), class: "px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300" %>
+    <%= submit_tag "Record charge", class: "btn btn-primary", data: { turbo_confirm: "Record this liability charge? Please verify amount, date, and category before continuing." } %>
+    <%= link_to "Cancel", finance_financial_liability_path(@financial_liability), class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80" %>
   </div>
 <% end %>

--- a/app/views/financial/liabilities/index.html.erb
+++ b/app/views/financial/liabilities/index.html.erb
@@ -10,9 +10,9 @@
   ) %>
 </div>
 
-<table class="min-w-full bg-white border">
+<table class="ui-table">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left">Name</th>
       <th class="px-4 py-2 text-left">Type</th>
       <th class="px-4 py-2 text-left">Status</th>
@@ -28,9 +28,9 @@
         <td class="px-4 py-2"><%= financial_liability.status.humanize %></td>
         <td class="px-4 py-2"><%= number_to_currency(financial_liability.current_balance) %></td>
         <td class="px-4 py-2">
-          <%= link_to "View", finance_financial_liability_path(financial_liability), class: "text-blue-500 hover:underline" %>
-          <%= link_to "Edit", edit_finance_financial_liability_path(financial_liability), class: "text-blue-500 hover:underline ml-2" %>
-          <%= link_to "Delete", finance_financial_liability_path(financial_liability), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-red-500 hover:underline ml-2" %>
+          <%= link_to "View", finance_financial_liability_path(financial_liability), class: "text-accent hover:underline" %>
+          <%= link_to "Edit", edit_finance_financial_liability_path(financial_liability), class: "text-accent hover:underline ml-2" %>
+          <%= link_to "Delete", finance_financial_liability_path(financial_liability), method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "text-danger hover:underline ml-2" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/financial/liabilities/payment.html.erb
+++ b/app/views/financial/liabilities/payment.html.erb
@@ -1,10 +1,10 @@
 <h1 class="text-2xl font-bold mb-4">Record Liability Payment</h1>
 
 <% if flash[:alert].present? %>
-  <div class="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-red-700"><%= flash[:alert] %></div>
+  <div class="mb-4 rounded border border-danger-soft bg-danger-soft px-4 py-3 text-danger"><%= flash[:alert] %></div>
 <% end %>
 
-<p class="mb-4 text-sm text-gray-600">
+<p class="mb-4 text-sm text-muted-foreground">
   Paying: <strong><%= @financial_liability.name %></strong>
   (Current owed: <%= number_to_currency(@financial_liability.current_balance) %>)
 </p>
@@ -12,28 +12,28 @@
 <%= form_with url: record_payment_finance_financial_liability_path(@financial_liability), method: :post, local: true do %>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div>
-      <%= label_tag "financial_liability_payment[financial_account_id]", "Pay from account", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_payment[financial_account_id]", "Pay from account", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= select_tag "financial_liability_payment[financial_account_id]", options_from_collection_for_select(@financial_accounts, :id, :name), include_blank: "Select source account", class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div>
-      <%= label_tag "financial_liability_payment[amount]", "Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_payment[amount]", "Amount", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= number_field_tag "financial_liability_payment[amount]", nil, step: 0.01, min: 0.01, max: @financial_liability.current_balance, class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div>
-      <%= label_tag "financial_liability_payment[entry_date]", "Date", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_payment[entry_date]", "Date", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= date_field_tag "financial_liability_payment[entry_date]", Date.current, class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
 
     <div>
-      <%= label_tag "financial_liability_payment[description]", "Description", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= label_tag "financial_liability_payment[description]", "Description", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= text_field_tag "financial_liability_payment[description]", "Payment to #{@financial_liability.name}", class: "border rounded px-3 py-2 w-full", required: true %>
     </div>
   </div>
 
   <div class="mt-6 flex gap-2">
-    <%= submit_tag "Record payment", class: "px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700", data: { turbo_confirm: "Record this liability payment? Please verify source account, amount, and date before continuing." } %>
-    <%= link_to "Cancel", finance_financial_liability_path(@financial_liability), class: "px-4 py-2 bg-gray-200 text-gray-700 rounded hover:bg-gray-300" %>
+    <%= submit_tag "Record payment", class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary/90", data: { turbo_confirm: "Record this liability payment? Please verify source account, amount, and date before continuing." } %>
+    <%= link_to "Cancel", finance_financial_liability_path(@financial_liability), class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80" %>
   </div>
 <% end %>

--- a/app/views/financial/liabilities/show.html.erb
+++ b/app/views/financial/liabilities/show.html.erb
@@ -1,26 +1,26 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← Back", finance_financial_liabilities_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← Back", finance_financial_liabilities_path, class: "text-accent hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @financial_liability.name %></h1>
 
 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Type</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Type</p>
     <p class="font-semibold"><%= @financial_liability.liability_type.humanize %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Status</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Status</p>
     <p class="font-semibold"><%= @financial_liability.status.humanize %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Opening Balance</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Opening Balance</p>
     <p class="font-semibold"><%= number_to_currency(@financial_liability.opening_balance) %></p>
   </div>
-  <div class="bg-gray-50 p-4 rounded">
-    <p class="text-sm text-gray-600">Current Balance</p>
+  <div class="bg-muted/35 p-4 rounded">
+    <p class="text-sm text-muted-foreground">Current Balance</p>
     <p class="font-semibold"><%= number_to_currency(@financial_liability.current_balance) %></p>
   </div>
 </div>

--- a/app/views/income_events/_form.html.erb
+++ b/app/views/income_events/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: [@budget_period, @income_event].compact, local: true, data: { controller: "income-event-form", income_event_form_loan_value: @income_event.loan? } do |form| %>
   <% if @income_event.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@income_event.errors.count, "error") %> prohibited this income event from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @income_event.errors.full_messages.each do |message| %>
@@ -11,87 +11,87 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :budget_period_id, "Budget Period (optional)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :budget_period_id, "Budget Period (optional)", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :budget_period_id, BudgetPeriod.all, :id, :name, { include_blank: "None" }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :income_type, "Income Type", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :income_type, "Income Type", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :income_type, [["Regular", "regular"], ["Loan", "loan"]], {}, { class: "border rounded px-3 py-2 w-full", data: { action: "change->income-event-form#toggleLoanFields", income_event_form_target: "incomeTypeSelect" } } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :description, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :description, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :description, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :expected_date, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :expected_date, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.date_field :expected_date, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4" data-income-event-form-target="expectedAmountField">
-    <%= form.label :expected_amount, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :expected_amount, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :expected_amount, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :destination_selection, "Destination Account", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :destination_selection, "Destination Account", class: "block text-sm font-medium text-foreground mb-1" %>
     <% destination_options = grouped_options_for_select({
       "Asset Accounts" => (@financial_assets || []).map { |asset| [asset.name, "asset:#{asset.id}"] },
       "Liability Accounts" => (@financial_liabilities || []).map { |liability| [liability.name, "liability:#{liability.id}"] }
     }, @income_event.destination_selection) %>
     <%= form.select :destination_selection, destination_options, { include_blank: "Select destination account" }, { class: "border rounded px-3 py-2 w-full" } %>
-    <p class="mt-1 text-xs text-gray-500">For regular income this is where money is credited. For loans this is disbursement destination.</p>
+    <p class="mt-1 text-xs text-muted-foreground">For regular income this is where money is credited. For loans this is disbursement destination.</p>
   </div>
 
   <div class="mb-4 hidden" data-income-event-form-target="loanFields">
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div>
-        <%= form.label :loan_amount, "Loan Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :loan_amount, "Loan Amount", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.number_field :loan_amount, step: 0.01, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "loanAmountField", action: "input->income-event-form#onSharedTermsChanged" } %>
       </div>
       <div>
-        <%= form.label :interest_rate, "Interest Rate (Annual %)", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :interest_rate, "Interest Rate (Annual %)", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.number_field :interest_rate, step: 0.001, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "interestRateField", action: "input->income-event-form#onInterestInput" } %>
-        <p class="mt-1 text-xs text-gray-500">Use annual nominal rate (APR). Example: 36 means 36% annual.</p>
-        <p class="mt-1 text-xs text-gray-500 hidden" data-income-event-form-target="interestHint"></p>
+        <p class="mt-1 text-xs text-muted-foreground">Use annual nominal rate (APR). Example: 36 means 36% annual.</p>
+        <p class="mt-1 text-xs text-muted-foreground hidden" data-income-event-form-target="interestHint"></p>
       </div>
       <div>
-        <%= form.label :number_of_payments, "Number of Payments", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :number_of_payments, "Number of Payments", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.number_field :number_of_payments, min: 1, step: 1, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "numberOfPaymentsField", action: "input->income-event-form#onSharedTermsChanged" } %>
       </div>
       <div>
-        <%= form.label :payment_frequency, "Payment Frequency", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :payment_frequency, "Payment Frequency", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.select :payment_frequency, [["Weekly (cada 7 dias)", "weekly"], ["Quincenal (cada 15 dias)", "quincenal"], ["Biweekly / Catorcenal (cada 14 dias)", "biweekly"], ["Monthly", "monthly"]], { include_blank: true }, { class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "paymentFrequencyField", action: "change->income-event-form#onSharedTermsChanged" } } %>
       </div>
       <div>
-        <%= form.label :payment_amount, "Payment Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :payment_amount, "Payment Amount", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.number_field :payment_amount, step: 0.01, class: "border rounded px-3 py-2 w-full", data: { income_event_form_target: "paymentAmountField", action: "input->income-event-form#onPaymentInput" } %>
       </div>
       <div>
-        <%= form.label :lender_name, "Lender Name", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :lender_name, "Lender Name", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.text_field :lender_name, class: "border rounded px-3 py-2 w-full" %>
       </div>
       <div>
-        <%= form.label :loan_liability_id, "Loan Origin Liability", class: "block text-sm font-medium text-gray-700 mb-1" %>
+        <%= form.label :loan_liability_id, "Loan Origin Liability", class: "block text-sm font-medium text-foreground mb-1" %>
         <%= form.collection_select :loan_liability_id, (@financial_liabilities || []), :id, :name, { include_blank: "Select liability account" }, { class: "border rounded px-3 py-2 w-full" } %>
       </div>
     </div>
     <div class="mt-4">
-      <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
       <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
     </div>
-    <p class="mt-2 text-xs text-gray-500">For loans, the expected date acts as the loan start date.</p>
+    <p class="mt-2 text-xs text-muted-foreground">For loans, the expected date acts as the loan start date.</p>
   </div>
 
   <div class="mb-4">
-    <%= form.label :status, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :status, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :status, [['Pending', 'pending'], ['Received', 'received'], ['Applied', 'applied']], {}, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", @income_event.persisted? ? @income_event : income_events_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to "Cancel", @income_event.persisted? ? @income_event : income_events_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>

--- a/app/views/income_events/_income_event_card.html.erb
+++ b/app/views/income_events/_income_event_card.html.erb
@@ -6,39 +6,32 @@
      0
    end %>
 
-<%= render Ui::CardComponent.new(
-  css_class: [
-    "flex h-full flex-col overflow-hidden p-0 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md",
-    prev_balance_negative ? "border-red-300 shadow-red-100/60" : "border-border/80"
-  ].join(" ")
-) do %>
-  <%= render Ui::CardHeaderComponent.new(css_class: "mb-0 space-y-1 border-b border-border/70 px-4 pt-2 pb-2.5") do %>
+<article class="flex h-full flex-col overflow-hidden rounded-xl border bg-card shadow-sm transition-shadow hover:shadow-md <%= prev_balance_negative ? 'border-danger-soft' : 'border-border' %>">
+  <header class="space-y-1 border-b border-border/70 px-4 pb-2.5 pt-2">
     <div class="flex justify-end leading-none">
-      <span class="inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[9px] leading-none font-medium uppercase tracking-wide <%= 
+      <span class="inline-flex shrink-0 items-center rounded-full border px-1.5 py-0.5 text-[9px] font-medium uppercase tracking-wide leading-none <%=
         case income_event.status
-        when 'pending' then 'border-yellow-200 bg-yellow-50 text-yellow-800'
-        when 'received' then 'border-blue-200 bg-blue-50 text-blue-800'
-        when 'applied' then 'border-green-200 bg-green-50 text-green-800'
-        else 'border-gray-200 bg-gray-50 text-gray-700'
+        when 'pending' then 'border-warning-soft bg-warning-soft text-warning'
+        when 'received' then 'border-border bg-muted/45 text-foreground'
+        when 'applied' then 'border-success-soft bg-success-soft text-success'
+        else 'border-border bg-muted/45 text-foreground'
         end
       %>">
         <%= t("income_events.form.#{income_event.status}") %>
       </span>
     </div>
 
-    <%= render Ui::CardTitleComponent.new(css_class: "w-full text-base leading-snug text-foreground sm:text-lg") do %>
-      <%= income_event.description %>
-    <% end %>
+    <h3 class="w-full text-base leading-snug text-foreground sm:text-lg font-semibold"><%= income_event.description %></h3>
 
-    <%= render Ui::CardDescriptionComponent.new(css_class: "flex items-center gap-1.5 text-[13px] leading-snug") do %>
+    <p class="flex items-center gap-1.5 text-[13px] leading-snug text-muted-foreground">
       <svg class="h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
       </svg>
       Expected <span class="font-medium text-foreground"><%= income_event.expected_date.strftime("%b %d, %Y") %></span>
-    <% end %>
-  <% end %>
+    </p>
+  </header>
 
-  <%= render Ui::CardContentComponent.new(css_class: "flex flex-1 flex-col gap-2 px-4 py-3") do %>
+  <div class="flex flex-1 flex-col gap-2 px-4 py-3">
     <div class="space-y-1.5">
       <div class="flex items-center justify-between gap-3">
         <span class="text-sm text-muted-foreground">Expected Amount</span>
@@ -48,7 +41,7 @@
       <% if income_event.received_date %>
         <div class="flex items-center justify-between gap-3 border-t border-border/60 pt-2">
           <span class="text-sm text-muted-foreground">Received</span>
-          <span class="text-sm font-medium text-green-700">
+          <span class="text-sm font-medium text-success">
             <%= income_event.received_date.strftime("%b %d") %> - <%= number_to_currency(income_event.received_amount) %>
           </span>
         </div>
@@ -56,11 +49,11 @@
 
       <div class="flex items-center justify-between gap-3 border-t border-border/60 pt-2">
         <span class="text-sm text-muted-foreground">Planned</span>
-        <span class="text-sm font-medium text-blue-700"><%= number_to_currency(income_event.total_planned) %></span>
+        <span class="text-sm font-medium text-accent"><%= number_to_currency(income_event.total_planned) %></span>
       </div>
 
       <% if prev_balance != 0 || income_event.previous_income_event %>
-        <div class="border-t border-border/60 pt-2 <%= prev_balance_negative ? 'rounded-md bg-red-50/70 px-3 py-2' : '' %>">
+        <div class="border-t border-border/60 pt-2 <%= prev_balance_negative ? 'rounded-md bg-danger-soft/70 px-3 py-2' : '' %>">
           <div class="flex items-center justify-between gap-2">
             <div class="min-w-0">
               <span class="text-sm text-muted-foreground">Previous Balance</span>
@@ -70,11 +63,11 @@
             </div>
             <div class="flex items-center gap-1.5">
               <% if prev_balance_negative %>
-                <svg class="h-4 w-4 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="h-4 w-4 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
                 </svg>
               <% end %>
-              <span class="text-sm font-semibold <%= prev_balance_negative ? 'text-red-600' : 'text-green-700' %>">
+              <span class="text-sm font-semibold <%= prev_balance_negative ? 'text-danger' : 'text-success' %>">
                 <%= number_to_currency(prev_balance) %>
               </span>
             </div>
@@ -84,7 +77,7 @@
 
       <div class="flex items-center justify-between gap-3 border-t border-border/60 pt-2">
         <span class="text-sm text-muted-foreground">Remaining</span>
-        <span class="text-sm font-semibold <%= income_event.effective_remaining_budget < 0 ? 'text-red-600' : 'text-green-700' %>">
+        <span class="text-sm font-semibold <%= income_event.effective_remaining_budget < 0 ? 'text-danger' : 'text-success' %>">
           <%= number_to_currency(income_event.effective_remaining_budget) %>
         </span>
       </div>
@@ -95,23 +88,24 @@
             <span>Planning Progress</span>
             <span class="font-semibold text-foreground"><%= planning_progress.round(1) %>%</span>
           </div>
-          <div class="h-2 w-full rounded-full bg-slate-200">
+          <div class="h-2 w-full rounded-full bg-muted">
             <div class="h-2 rounded-full bg-primary transition-all duration-300" style="width: <%= [planning_progress, 100].min %>%"></div>
           </div>
         </div>
       <% end %>
     </div>
-  <% end %>
+  </div>
 
-  <%= render Ui::CardFooterComponent.new(css_class: "mt-auto border-t border-border/70 px-5 py-3") do %>
+  <footer class="mt-auto border-t border-border/70 px-5 py-3">
     <div class="grid grid-cols-2 gap-2">
       <%= render Ui::ButtonComponent.new(href: income_event, label: "View", variant: "outline", size: "sm", css_class: "w-full justify-center") do %>
-          <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
-          </svg>
+        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+        </svg>
       <% end %>
       <%= render Ui::ButtonComponent.new(href: edit_income_event_path(income_event), label: "Edit", variant: "outline", size: "sm", css_class: "w-full justify-center") %>
+
       <% unless income_event.is_received? %>
         <%= render Ui::ButtonComponent.new(
           href: receive_income_event_path(income_event),
@@ -143,5 +137,5 @@
         css_class: "w-full justify-center"
       ) %>
     </div>
-  <% end %>
-<% end %>
+  </footer>
+</article>

--- a/app/views/income_events/_month_header.html.erb
+++ b/app/views/income_events/_month_header.html.erb
@@ -10,33 +10,32 @@
   event_count = events.count
 %>
 
-<div class="mb-6 mt-8 first:mt-0" id="month-<%= month_date.strftime('%Y-%m') %>">
-  <!-- Month Header -->
-  <div class="bg-gradient-to-r from-indigo-50 to-indigo-100 rounded-lg px-6 py-4 border-l-4 border-indigo-500 shadow-sm mb-4">
+<div class="mb-5 mt-8 first:mt-0" id="month-<%= month_date.strftime('%Y-%m') %>">
+  <div class="mb-4 rounded-xl border border-border bg-card px-5 py-4 shadow-sm">
     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
       <div>
-        <h2 class="text-2xl font-bold text-indigo-900">
+        <h2 class="text-xl font-semibold text-foreground sm:text-2xl">
           <%= month_date.strftime("%B %Y") %>
         </h2>
-        <p class="text-sm text-indigo-700 mt-1">
+        <p class="text-sm text-muted-foreground mt-1">
           <%= pluralize(event_count, 'income event') %>
         </p>
       </div>
       
       <!-- Month Summary Stats -->
-      <div class="flex flex-wrap gap-4 md:gap-6">
+      <div class="flex flex-wrap gap-3 md:gap-4">
         <div class="flex items-center gap-2">
-          <div class="bg-white rounded-lg px-3 py-2 shadow-sm">
-            <p class="text-xs text-gray-600">Expected</p>
-            <p class="text-sm font-bold text-gray-900"><%= number_to_currency(total_expected) %></p>
+          <div class="rounded-lg border border-border bg-secondary/45 px-3 py-2">
+            <p class="text-xs text-muted-foreground">Expected</p>
+            <p class="text-sm font-semibold text-foreground"><%= number_to_currency(total_expected) %></p>
           </div>
         </div>
         
         <% if total_received > 0 %>
           <div class="flex items-center gap-2">
-            <div class="bg-white rounded-lg px-3 py-2 shadow-sm">
-              <p class="text-xs text-gray-600">Received</p>
-              <p class="text-sm font-bold text-green-700"><%= number_to_currency(total_received) %></p>
+            <div class="rounded-lg border border-border bg-secondary/45 px-3 py-2">
+              <p class="text-xs text-muted-foreground">Received</p>
+              <p class="text-sm font-semibold text-success"><%= number_to_currency(total_received) %></p>
             </div>
           </div>
         <% end %>
@@ -44,12 +43,12 @@
         <div class="flex items-center gap-2">
           <div class="flex gap-2">
             <% if pending_count > 0 %>
-              <span class="px-2 py-1 rounded text-xs font-medium bg-yellow-100 text-yellow-800 border border-yellow-200">
+              <span class="rounded border border-warning-soft bg-warning-soft px-2 py-1 text-xs font-medium text-warning">
                 <%= pending_count %> pending
               </span>
             <% end %>
             <% if received_count > 0 %>
-              <span class="px-2 py-1 rounded text-xs font-medium bg-green-100 text-green-800 border border-green-200">
+              <span class="rounded border border-success-soft bg-success-soft px-2 py-1 text-xs font-medium text-success">
                 <%= received_count %> received
               </span>
             <% end %>

--- a/app/views/income_events/index.html.erb
+++ b/app/views/income_events/index.html.erb
@@ -1,253 +1,79 @@
-<p style="color: green"><%= notice %></p>
-
-<div class="mb-6">
-  <div class="flex justify-between items-center mb-6">
-    <h1 class="text-3xl font-bold text-gray-900">Income Events</h1>
+<section class="space-y-6 p-6 sm:p-8">
+  <header class="flex flex-col gap-4 rounded-2xl border border-border bg-card p-5 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight text-foreground sm:text-3xl">Income Events</h1>
+      <p class="mt-1 text-sm text-muted-foreground">Track expected income, planning status, and remaining balance with a calmer scan flow.</p>
+    </div>
     <%= render Ui::ButtonComponent.new(
       href: @budget_period ? new_budget_period_income_event_path(@budget_period) : new_income_event_path,
       label: "New Income Event",
-      variant: "default"
+      variant: :default,
+      css_class: "h-10"
     ) %>
-  </div>
+  </header>
 
   <% if @budget_period %>
-    <div class="bg-indigo-50 border-l-4 border-indigo-500 p-4 rounded mb-6">
-      <p class="text-indigo-800 font-medium">Budget Period: <span class="font-semibold"><%= @budget_period.name %></span></p>
-    </div>
+    <section class="rounded-xl border border-border bg-secondary/45 p-4">
+      <p class="text-sm font-medium text-foreground">Budget Period: <span class="font-semibold"><%= @budget_period.name %></span></p>
+    </section>
   <% end %>
 
-  <!-- Month Selector -->
   <% if @income_events.any? && @available_months.any? %>
-    <div class="mb-6">
-      <div class="flex items-center gap-3">
-        <label for="month-selector" class="text-sm font-medium text-gray-700">Filter by month:</label>
-        <%= form_with url: @budget_period ? budget_period_income_events_path(@budget_period) : income_events_path, method: :get, local: true, class: "inline-block" do |f| %>
-          <%= f.select :month, 
+    <section class="rounded-xl border border-border bg-card p-4 shadow-sm">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <label for="month-selector" class="text-sm font-medium text-foreground">Filter by month</label>
+        <%= form_with url: @budget_period ? budget_period_income_events_path(@budget_period) : income_events_path, method: :get, local: true do |f| %>
+          <%= f.select :month,
               options_for_select(
                 [["All Months", ""]] + @available_months.map { |m| [m.strftime("%B %Y"), m.strftime("%Y-%m-%d")] },
                 @selected_month ? @selected_month.strftime("%Y-%m-%d") : ""
               ),
               { include_blank: false },
-              { 
+              {
                 id: "month-selector",
-                class: "rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm",
+                class: "rounded-md border-input bg-card px-3 py-2 text-sm shadow-sm focus:border-primary focus:ring-primary",
                 onchange: "this.form.submit()"
               } %>
         <% end %>
       </div>
-    </div>
+    </section>
   <% end %>
 
-  <!-- Summary Cards -->
   <% if @income_events.any? %>
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8">
-      <div class="bg-gradient-to-br from-blue-50 to-blue-100 rounded-xl p-6 shadow-sm border border-blue-200">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm font-medium text-blue-600 mb-1">Total Expected</p>
-            <p class="text-2xl font-bold text-blue-900"><%= number_to_currency(@income_events.sum { |ie| ie.expected_amount }) %></p>
-          </div>
-          <div class="bg-blue-500 rounded-full p-3">
-            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
+    <section class="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <article class="rounded-xl border border-border bg-card p-5 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Total Expected</p>
+        <p class="mt-2 text-2xl font-bold text-foreground"><%= number_to_currency(@income_events.sum { |ie| ie.expected_amount }) %></p>
+      </article>
+      <article class="rounded-xl border border-warning-soft bg-card p-5 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Pending Events</p>
+        <p class="mt-2 text-2xl font-bold text-warning"><%= @income_events.count { |ie| ie.status == 'pending' } %></p>
+      </article>
+      <article class="rounded-xl border border-success-soft bg-card p-5 shadow-sm">
+        <p class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Received / Applied</p>
+        <p class="mt-2 text-2xl font-bold text-success"><%= @income_events.count { |ie| ie.status == 'received' || ie.status == 'applied' } %></p>
+      </article>
+    </section>
 
-      <div class="bg-gradient-to-br from-yellow-50 to-yellow-100 rounded-xl p-6 shadow-sm border border-yellow-200">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm font-medium text-yellow-600 mb-1">Pending</p>
-            <p class="text-2xl font-bold text-yellow-900"><%= @income_events.select { |ie| ie.status == 'pending' }.count %></p>
-          </div>
-          <div class="bg-yellow-500 rounded-full p-3">
-            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-          </div>
-        </div>
+    <% @grouped_events.each do |month_date, month_events| %>
+      <%= render partial: "month_header", locals: { month_date: month_date, events: month_events } %>
+      <section class="grid grid-cols-1 gap-5 md:grid-cols-2">
+        <% month_events.each do |income_event| %>
+          <%= render partial: "income_event_card", locals: { income_event: income_event } %>
+        <% end %>
+      </section>
+    <% end %>
+  <% else %>
+    <section class="rounded-xl border-2 border-dashed border-input bg-card py-12 text-center">
+      <h2 class="text-base font-semibold text-foreground">No income events</h2>
+      <p class="mt-1 text-sm text-muted-foreground">Create your first income event to start planning.</p>
+      <div class="mt-5">
+        <%= render Ui::ButtonComponent.new(
+          href: @budget_period ? new_budget_period_income_event_path(@budget_period) : new_income_event_path,
+          label: "New Income Event",
+          variant: :default
+        ) %>
       </div>
-
-      <div class="bg-gradient-to-br from-green-50 to-green-100 rounded-xl p-6 shadow-sm border border-green-200">
-        <div class="flex items-center justify-between">
-          <div>
-            <p class="text-sm font-medium text-green-600 mb-1">Received</p>
-            <p class="text-2xl font-bold text-green-900"><%= @income_events.select { |ie| ie.status == 'received' || ie.status == 'applied' }.count %></p>
-          </div>
-          <div class="bg-green-500 rounded-full p-3">
-            <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
+    </section>
   <% end %>
-</div>
-
-<% if @income_events.any? %>
-  <!-- Grouped by Month -->
-  <% @grouped_events.each do |month_date, month_events| %>
-    <%= render partial: 'month_header', locals: { month_date: month_date, events: month_events } %>
-    
-    <!-- Card Grid Layout for this month -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-      <% month_events.each do |income_event| %>
-        <% prev_balance_negative = income_event.previous_balance < 0 %>
-        <div class="bg-white rounded-xl shadow-md hover:shadow-xl transition-shadow duration-200 border <%= prev_balance_negative ? 'border-red-300 border-2' : 'border-gray-200' %> overflow-hidden">
-          <!-- Card Header -->
-          <div class="bg-gradient-to-r from-gray-50 to-gray-100 px-6 py-4 border-b border-gray-200">
-            <div class="flex items-center justify-between mb-2">
-              <h3 class="text-lg font-semibold text-gray-900"><%= income_event.description %></h3>
-              <span class="px-3 py-1 rounded-full text-xs font-medium <%= 
-                case income_event.status
-                when 'pending' then 'bg-yellow-100 text-yellow-800 border border-yellow-200'
-                when 'received' then 'bg-blue-100 text-blue-800 border border-blue-200'
-                when 'applied' then 'bg-green-100 text-green-800 border border-green-200'
-                else 'bg-gray-100 text-gray-800 border border-gray-200'
-                end
-              %>">
-                <%= t("income_events.form.#{income_event.status}") %>
-              </span>
-            </div>
-            <p class="text-sm text-gray-600">
-              <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-              </svg>
-              Expected: <%= income_event.expected_date.strftime("%b %d, %Y") %>
-            </p>
-          </div>
-
-          <!-- Card Body -->
-          <div class="px-6 py-4">
-            <div class="space-y-3">
-              <div class="flex justify-between items-center">
-                <span class="text-sm text-gray-600">Expected Amount</span>
-                <span class="text-lg font-bold text-gray-900"><%= number_to_currency(income_event.expected_amount) %></span>
-              </div>
-              
-              <% if income_event.received_date %>
-                <div class="flex justify-between items-center pt-2 border-t border-gray-100">
-                  <span class="text-sm text-gray-600">Received</span>
-                  <span class="text-sm font-medium text-green-600">
-                    <%= income_event.received_date.strftime("%b %d") %> - <%= number_to_currency(income_event.received_amount) %>
-                  </span>
-                </div>
-              <% end %>
-
-              <% prev_balance = income_event.previous_balance %>
-              <% if prev_balance != 0 || income_event.previous_income_event %>
-                <div class="flex justify-between items-center pt-2 border-t border-gray-100 <%= prev_balance < 0 ? 'bg-red-50 -mx-6 px-6 py-2 border-l-4 border-red-400' : '' %>">
-                  <div class="flex items-center gap-1">
-                    <span class="text-sm text-gray-600">Previous Balance</span>
-                    <% if income_event.previous_income_event %>
-                      <span class="text-xs text-gray-500">(from <%= income_event.previous_income_event.description %>)</span>
-                    <% end %>
-                  </div>
-                  <div class="flex items-center gap-1">
-                    <% if prev_balance < 0 %>
-                      <svg class="w-4 h-4 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                      </svg>
-                    <% end %>
-                    <span class="text-sm font-semibold <%= prev_balance < 0 ? 'text-red-600' : 'text-green-600' %>">
-                      <%= number_to_currency(prev_balance) %>
-                    </span>
-                  </div>
-                </div>
-              <% end %>
-
-              <div class="flex justify-between items-center pt-2 border-t border-gray-100">
-                <span class="text-sm text-gray-600">Planned</span>
-                <span class="text-sm font-medium text-blue-600"><%= number_to_currency(income_event.total_planned) %></span>
-              </div>
-
-              <div class="flex justify-between items-center pt-2 border-t border-gray-100">
-                <span class="text-sm text-gray-600">Remaining</span>
-                <span class="text-sm font-semibold <%= income_event.effective_remaining_budget < 0 ? 'text-red-600' : 'text-green-600' %>">
-                  <%= number_to_currency(income_event.effective_remaining_budget) %>
-                </span>
-              </div>
-
-              <!-- Progress Bar -->
-              <% if income_event.expected_amount > 0 %>
-                <div class="pt-3">
-                  <div class="flex justify-between text-xs text-gray-600 mb-1">
-                    <span>Planning Progress</span>
-                    <span><%= ((income_event.total_planned / income_event.expected_amount) * 100).round(1) %>%</span>
-                  </div>
-                  <div class="w-full bg-gray-200 rounded-full h-2">
-                    <div class="bg-blue-500 h-2 rounded-full transition-all duration-300" style="width: <%= [((income_event.total_planned / income_event.expected_amount) * 100), 100].min %>%"></div>
-                  </div>
-                </div>
-              <% end %>
-            </div>
-          </div>
-
-          <!-- Card Footer -->
-          <div class="bg-gray-50 px-6 py-4 border-t border-gray-200 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div class="flex flex-col gap-2 w-full sm:w-auto sm:flex-row sm:flex-wrap">
-              <%= render Ui::ButtonComponent.new(href: income_event, label: "View", variant: "outline", size: "sm", css_class: "w-full sm:w-auto justify-center") do %>
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
-                </svg>
-              <% end %>
-              <%= render Ui::ButtonComponent.new(href: edit_income_event_path(income_event), label: "Edit", variant: "outline", size: "sm", css_class: "w-full sm:w-auto justify-center") %>
-              <% if income_event.loan? %>
-                <%= render Ui::ButtonComponent.new(href: loan_summary_income_event_path(income_event), label: "Loan Summary", variant: "outline", size: "sm", css_class: "w-full sm:w-auto justify-center") %>
-              <% end %>
-            </div>
-            <div class="flex flex-col gap-2 w-full sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end">
-              <% unless income_event.is_received? %>
-                <%= render Ui::ButtonComponent.new(
-                  href: receive_income_event_path(income_event),
-                  label: "Mark Received",
-                  variant: "default",
-                  size: "sm",
-                  css_class: "w-full sm:w-auto justify-center"
-                ) %>
-              <% end %>
-              <% if income_event.is_received? && !income_event.is_applied? %>
-                <%= render Ui::ButtonComponent.new(
-                  href: apply_all_income_event_path(income_event),
-                  label: "Apply All",
-                  variant: "default",
-                  method: :post,
-                  size: "sm",
-                  css_class: "w-full sm:w-auto justify-center"
-                ) %>
-              <% end %>
-              <%= render Ui::ButtonComponent.new(
-                href: income_event,
-                label: "Delete",
-                variant: "destructive",
-                method: :delete,
-                data: { turbo_confirm: "Are you sure? This will delete all associated planned expenses." },
-                size: "sm",
-                css_class: "w-full sm:w-auto justify-center"
-              ) %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    </div>
-  <% end %>
-<% else %>
-  <!-- Empty State -->
-  <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
-    <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-    </svg>
-    <h3 class="mt-2 text-sm font-medium text-gray-900">No income events</h3>
-    <p class="mt-1 text-sm text-gray-500">Get started by creating your first income event.</p>
-    <div class="mt-6">
-      <%= render Ui::ButtonComponent.new(
-        href: @budget_period ? new_budget_period_income_event_path(@budget_period) : new_income_event_path,
-        label: "New Income Event",
-        variant: "default"
-      ) %>
-    </div>
-  </div>
-<% end %>
+</section>

--- a/app/views/income_events/loan_summary.html.erb
+++ b/app/views/income_events/loan_summary.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-6">
-  <%= link_to @income_event, class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+  <%= link_to @income_event, class: "inline-flex items-center text-accent hover:text-foreground transition-colors mb-4" do %>
     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
     </svg>
@@ -9,83 +9,83 @@
   <% end %>
 </div>
 
-<div class="bg-gradient-to-r from-slate-900 to-slate-700 rounded-2xl shadow-xl p-8 mb-8 text-white">
+<div class="rounded-2xl border border-border bg-[linear-gradient(135deg,color-mix(in_oklab,hsl(var(--card))_90%,hsl(var(--background))_10%),hsl(var(--card)))] shadow-sm p-8 mb-8 text-foreground">
   <div class="flex items-start justify-between gap-6 flex-wrap">
     <div>
       <h1 class="text-3xl font-bold mb-2"><%= @income_event.description %></h1>
-      <p class="text-slate-200">Loan summary and repayment checklist</p>
+      <p class="text-muted-foreground">Loan summary and repayment checklist</p>
     </div>
     <div class="text-right">
-      <p class="text-slate-300 text-sm">Start date</p>
+      <p class="text-muted-foreground text-sm">Start date</p>
       <p class="text-lg font-semibold"><%= @income_event.expected_date.strftime("%B %d, %Y") %></p>
     </div>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-5 gap-4 mt-8">
-    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
-      <p class="text-slate-300 text-sm">Loan amount</p>
+    <div class="bg-muted/35 rounded-xl p-4 border border-border">
+      <p class="text-muted-foreground text-sm">Loan amount</p>
       <p class="text-2xl font-bold"><%= number_to_currency(@income_event.loan_amount || @income_event.expected_amount) %></p>
     </div>
-    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
-      <p class="text-slate-300 text-sm">Interest rate</p>
+    <div class="bg-muted/35 rounded-xl p-4 border border-border">
+      <p class="text-muted-foreground text-sm">Interest rate</p>
       <p class="text-2xl font-bold"><%= number_with_precision(@income_event.interest_rate || 0, precision: 3) %>%</p>
-      <p class="text-xs text-slate-300 mt-1"><%= @income_event.inferred_interest_rate? ? "Estimated from payment amount" : "Provided by user" %></p>
+      <p class="text-xs text-muted-foreground mt-1"><%= @income_event.inferred_interest_rate? ? "Estimated from payment amount" : "Provided by user" %></p>
     </div>
-    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
-      <p class="text-slate-300 text-sm">Total repayable</p>
+    <div class="bg-muted/35 rounded-xl p-4 border border-border">
+      <p class="text-muted-foreground text-sm">Total repayable</p>
       <p class="text-2xl font-bold"><%= number_to_currency(@income_event.loan_total_repayment) %></p>
     </div>
-    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
-      <p class="text-slate-300 text-sm">Remaining balance</p>
+    <div class="bg-muted/35 rounded-xl p-4 border border-border">
+      <p class="text-muted-foreground text-sm">Remaining balance</p>
       <p class="text-2xl font-bold"><%= number_to_currency(@income_event.loan_remaining_balance) %></p>
     </div>
-    <div class="bg-white/10 rounded-xl p-4 border border-white/20">
-      <p class="text-slate-300 text-sm">Payments</p>
+    <div class="bg-muted/35 rounded-xl p-4 border border-border">
+      <p class="text-muted-foreground text-sm">Payments</p>
       <p class="text-2xl font-bold"><%= @loan_payment_schedules.count %></p>
     </div>
   </div>
 </div>
 
 <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 mb-8">
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-    <h2 class="text-xl font-semibold text-gray-900 mb-4">Payment schedule</h2>
+  <div class="bg-card rounded-xl shadow-sm border border-border p-6">
+    <h2 class="text-xl font-semibold text-foreground mb-4">Payment schedule</h2>
     <% if @loan_payment_schedules.any? %>
       <div class="space-y-3">
         <% @loan_payment_schedules.each do |schedule| %>
-          <div class="flex items-center justify-between rounded-lg border border-gray-200 p-4 <%= schedule.paid? ? 'bg-green-50' : 'bg-white' %>">
+          <div class="flex items-center justify-between rounded-lg border border-border p-4 <%= schedule.paid? ? 'bg-success-soft' : 'bg-card' %>">
             <div>
-              <p class="font-medium text-gray-900">Payment <%= schedule.installment_number %></p>
-              <p class="text-sm text-gray-600"><%= schedule.due_date.strftime("%b %d, %Y") %></p>
+              <p class="font-medium text-foreground">Payment <%= schedule.installment_number %></p>
+              <p class="text-sm text-muted-foreground"><%= schedule.due_date.strftime("%b %d, %Y") %></p>
             </div>
             <div class="text-right">
-              <p class="font-semibold text-gray-900"><%= number_to_currency(schedule.amount) %></p>
-              <p class="text-xs text-gray-500"><%= schedule.status %></p>
+              <p class="font-semibold text-foreground"><%= number_to_currency(schedule.amount) %></p>
+              <p class="text-xs text-muted-foreground"><%= schedule.status %></p>
             </div>
           </div>
         <% end %>
       </div>
     <% else %>
-      <p class="text-gray-600">No payment schedule has been generated yet.</p>
+      <p class="text-muted-foreground">No payment schedule has been generated yet.</p>
     <% end %>
   </div>
 
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
-    <h2 class="text-xl font-semibold text-gray-900 mb-4">Checklist</h2>
-    <p class="text-sm text-gray-600 mb-4">Planned expenses and loan payments together for execution.</p>
+  <div class="bg-card rounded-xl shadow-sm border border-border p-6">
+    <h2 class="text-xl font-semibold text-foreground mb-4">Checklist</h2>
+    <p class="text-sm text-muted-foreground mb-4">Planned expenses and loan payments together for execution.</p>
 
     <% if @planned_expenses.any? %>
       <div class="mb-6">
-        <h3 class="text-sm font-semibold text-gray-700 mb-2">Planned expenses</h3>
+        <h3 class="text-sm font-semibold text-foreground mb-2">Planned expenses</h3>
         <div class="space-y-2">
           <% @planned_expenses.each do |planned_expense| %>
-            <div class="rounded-lg border border-gray-200 px-4 py-3">
+            <div class="rounded-lg border border-border px-4 py-3">
               <div class="flex items-center justify-between gap-3">
-                <%= link_to [planned_expense.income_event, planned_expense], class: "text-sm text-blue-700 hover:text-blue-900 hover:underline" do %>
+                <%= link_to [planned_expense.income_event, planned_expense], class: "text-sm text-accent hover:text-foreground hover:underline" do %>
                   <%= planned_expense.description %>
                 <% end %>
-                <span class="text-sm font-medium text-gray-700"><%= number_to_currency(planned_expense.amount) %></span>
+                <span class="text-sm font-medium text-foreground"><%= number_to_currency(planned_expense.amount) %></span>
               </div>
-              <p class="mt-1 text-xs text-gray-500">
+              <p class="mt-1 text-xs text-muted-foreground">
                 Pays from:
                 <% if planned_expense.income_event_id == @income_event.id %>
                   this loan event
@@ -101,12 +101,12 @@
 
     <% if @loan_payment_schedules.any? %>
       <div>
-        <h3 class="text-sm font-semibold text-gray-700 mb-2">Loan payments</h3>
+        <h3 class="text-sm font-semibold text-foreground mb-2">Loan payments</h3>
         <div class="space-y-2">
           <% @loan_payment_schedules.each do |schedule| %>
-            <div class="flex items-center justify-between rounded-lg border border-gray-200 px-4 py-3">
-              <span class="text-sm text-gray-900">Payment <%= schedule.installment_number %></span>
-              <span class="text-sm font-medium text-gray-700"><%= number_to_currency(schedule.amount) %></span>
+            <div class="flex items-center justify-between rounded-lg border border-border px-4 py-3">
+              <span class="text-sm text-foreground">Payment <%= schedule.installment_number %></span>
+              <span class="text-sm font-medium text-foreground"><%= number_to_currency(schedule.amount) %></span>
             </div>
           <% end %>
         </div>

--- a/app/views/income_events/receive.html.erb
+++ b/app/views/income_events/receive.html.erb
@@ -2,22 +2,22 @@
 
 <%= form_with model: @income_event, url: receive_income_event_path(@income_event), method: :patch, local: true do |form| %>
   <div class="mb-4">
-    <p class="text-gray-600 mb-2">Expected: <%= number_to_currency(@income_event.expected_amount) %> on <%= @income_event.expected_date %></p>
+    <p class="text-muted-foreground mb-2">Expected: <%= number_to_currency(@income_event.expected_amount) %> on <%= @income_event.expected_date %></p>
   </div>
 
   <div class="mb-4">
-    <%= form.label :received_date, "Received Date", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :received_date, "Received Date", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.date_field :received_date, value: Date.current, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :received_amount, "Received Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :received_amount, "Received Amount", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :received_amount, value: @income_event.expected_amount, step: 0.01, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit "Mark as Received", class: "px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600" %>
-    <%= link_to "Cancel", @income_event, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit "Mark as Received", class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary/90" %>
+    <%= link_to "Cancel", @income_event, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/income_events/show.html.erb
+++ b/app/views/income_events/show.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-6">
-  <%= link_to income_events_path, class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+  <%= link_to income_events_path, class: "inline-flex items-center text-accent hover:text-foreground transition-colors mb-4" do %>
     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
     </svg>
@@ -10,11 +10,11 @@
 </div>
 
 <!-- Hero Section -->
-<div class="bg-gradient-to-r from-blue-600 to-indigo-700 rounded-2xl shadow-xl p-8 mb-8 text-white">
+<div class="rounded-2xl border border-border bg-[linear-gradient(135deg,color-mix(in_oklab,hsl(var(--card))_90%,hsl(var(--background))_10%),hsl(var(--card)))] shadow-sm p-8 mb-8 text-foreground">
   <div class="flex items-center justify-between mb-6">
     <div>
       <h1 class="text-3xl font-bold mb-2"><%= @income_event.description %></h1>
-      <div class="flex items-center gap-4 text-blue-100">
+      <div class="flex items-center gap-4 text-muted-foreground">
         <span class="flex items-center">
           <svg class="w-5 h-5 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
@@ -31,11 +31,11 @@
         <% end %>
       </div>
     </div>
-    <span class="px-4 py-2 rounded-full text-sm font-medium bg-white/20 backdrop-blur-sm border border-white/30 <%= 
+    <span class="px-4 py-2 rounded-full text-sm font-medium bg-muted/35 border border-border <%= 
       case @income_event.status
-      when 'pending' then 'bg-yellow-500/20 text-yellow-100 border-yellow-300/30'
-      when 'received' then 'bg-blue-500/20 text-blue-100 border-blue-300/30'
-      when 'applied' then 'bg-green-500/20 text-green-100 border-green-300/30'
+      when 'pending' then 'bg-warning-soft text-warning border-warning-soft'
+      when 'received' then 'bg-muted text-foreground border-border'
+      when 'applied' then 'bg-success-soft text-success border-success-soft'
       end
     %>">
       <%= t("income_events.form.#{@income_event.status}") %>
@@ -47,49 +47,49 @@
   <% prev_event = @income_event.previous_income_event %>
   <% has_previous = prev_balance != 0 || prev_event %>
   <div class="grid grid-cols-1 md:grid-cols-2 <%= has_previous ? 'lg:grid-cols-5' : 'lg:grid-cols-4' %> gap-6">
-    <div class="bg-white/10 backdrop-blur-sm rounded-xl p-6 border border-white/20">
-      <p class="text-blue-100 text-sm mb-2">Income Amount</p>
+    <div class="bg-muted/35 rounded-xl p-6 border border-border">
+      <p class="text-muted-foreground text-sm mb-2">Income Amount</p>
       <p class="text-3xl font-bold"><%= number_to_currency(@income_event.received_amount || @income_event.expected_amount) %></p>
       <% if @income_event.received_date %>
-        <p class="text-blue-200 text-xs mt-2">Received: <%= @income_event.received_date.strftime("%b %d") %></p>
+        <p class="text-muted-foreground text-xs mt-2">Received: <%= @income_event.received_date.strftime("%b %d") %></p>
       <% end %>
     </div>
     <% if prev_balance != 0 || prev_event %>
-      <div class="bg-white/10 backdrop-blur-sm rounded-xl p-6 border <%= prev_balance < 0 ? 'border-red-300/50 border-2' : 'border-white/20' %>">
+      <div class="bg-muted/35 rounded-xl p-6 border <%= prev_balance < 0 ? 'border-danger-soft border-2' : 'border-border' %>">
         <div class="flex items-center gap-2 mb-2">
-          <p class="text-blue-100 text-sm">Previous Balance</p>
+          <p class="text-muted-foreground text-sm">Previous Balance</p>
           <% if prev_balance < 0 %>
-            <svg class="w-4 h-4 text-red-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-4 h-4 text-danger" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
             </svg>
           <% end %>
         </div>
-        <p class="text-3xl font-bold <%= prev_balance < 0 ? 'text-red-200' : 'text-green-200' %>">
+        <p class="text-3xl font-bold <%= prev_balance < 0 ? 'text-danger' : 'text-success' %>">
           <%= number_to_currency(prev_balance) %>
         </p>
         <% if prev_event %>
-          <p class="text-blue-200 text-xs mt-2">From: <%= prev_event.description %></p>
+          <p class="text-muted-foreground text-xs mt-2">From: <%= prev_event.description %></p>
         <% end %>
       </div>
     <% end %>
-    <div class="bg-white/10 backdrop-blur-sm rounded-xl p-6 border border-white/20">
-      <p class="text-blue-100 text-sm mb-2">Total Planned</p>
+    <div class="bg-muted/35 rounded-xl p-6 border border-border">
+      <p class="text-muted-foreground text-sm mb-2">Total Planned</p>
       <p class="text-3xl font-bold"><%= number_to_currency(@income_event.total_planned) %></p>
-      <p class="text-blue-200 text-xs mt-2">
+      <p class="text-muted-foreground text-xs mt-2">
         <%= @planned_expenses.count %> planned + <%= @direct_expenses.count %> direct
       </p>
     </div>
-    <div class="bg-white/10 backdrop-blur-sm rounded-xl p-6 border border-white/20">
-      <p class="text-blue-100 text-sm mb-2">Total Spent</p>
+    <div class="bg-muted/35 rounded-xl p-6 border border-border">
+      <p class="text-muted-foreground text-sm mb-2">Total Spent</p>
       <p class="text-3xl font-bold"><%= number_to_currency(@income_event.total_spent) %></p>
-      <p class="text-blue-200 text-xs mt-2"><%= @income_event.expenses.count %> expenses</p>
+      <p class="text-muted-foreground text-xs mt-2"><%= @income_event.expenses.count %> expenses</p>
     </div>
-    <div class="bg-white/10 backdrop-blur-sm rounded-xl p-6 border border-white/20">
-      <p class="text-blue-100 text-sm mb-2">Effective Remaining</p>
-      <p class="text-3xl font-bold <%= @income_event.effective_remaining_budget < 0 ? 'text-red-200' : 'text-green-200' %>">
+    <div class="bg-muted/35 rounded-xl p-6 border border-border">
+      <p class="text-muted-foreground text-sm mb-2">Effective Remaining</p>
+      <p class="text-3xl font-bold <%= @income_event.effective_remaining_budget < 0 ? 'text-danger' : 'text-success' %>">
         <%= number_to_currency(@income_event.effective_remaining_budget) %>
       </p>
-      <p class="text-blue-200 text-xs mt-2">
+      <p class="text-muted-foreground text-xs mt-2">
         <% if prev_balance != 0 %>
           After carryover
         <% else %>
@@ -101,8 +101,8 @@
   
   <!-- Breakdown Section -->
   <% if prev_balance != 0 || prev_event %>
-    <div class="mt-6 bg-white/10 backdrop-blur-sm rounded-xl p-4 border border-white/20">
-      <p class="text-blue-100 text-sm">
+    <div class="mt-6 bg-muted/35 rounded-xl p-4 border border-border">
+      <p class="text-muted-foreground text-sm">
         <strong>Calculation:</strong> 
         <%= number_to_currency(@income_event.received_amount || @income_event.expected_amount) %> (Income)
         <% if prev_balance < 0 %>
@@ -164,7 +164,7 @@
 <!-- Planned Expenses Section -->
 <div class="mb-6">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-2xl font-bold text-gray-900">Planned Expenses</h2>
+    <h2 class="text-2xl font-bold text-foreground">Planned Expenses</h2>
     <%= render Ui::ButtonComponent.new(
       href: new_income_event_planned_expense_path(@income_event),
       label: "Add Expense",
@@ -175,18 +175,18 @@
   <% if @planned_expenses.any? %>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       <% @planned_expenses.each do |planned_expense| %>
-        <div class="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-gray-200 p-5">
+        <div class="bg-card rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-border p-5">
           <div class="flex items-start justify-between mb-3">
             <div class="flex-1">
-              <h3 class="font-semibold text-gray-900 mb-1"><%= planned_expense.description %></h3>
-              <p class="text-sm text-gray-600"><%= planned_expense.category.name %></p>
+              <h3 class="font-semibold text-foreground mb-1"><%= planned_expense.description %></h3>
+              <p class="text-sm text-muted-foreground"><%= planned_expense.category.name %></p>
             </div>
             <span class="px-2.5 py-1 rounded-full text-xs font-medium <%= 
               case planned_expense.status
-              when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-yellow-100 text-yellow-800 border border-yellow-200'
-              when 'transferring' then 'bg-blue-100 text-blue-800 border border-blue-200'
-              when 'paid', 'transferred', 'spent' then 'bg-green-100 text-green-800 border border-green-200'
-              else 'bg-gray-100 text-gray-800 border border-gray-200'
+              when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-warning-soft text-warning border border-warning-soft'
+              when 'transferring' then 'bg-muted text-foreground border border-border'
+              when 'paid', 'transferred', 'spent' then 'bg-success-soft text-success border border-success-soft'
+              else 'bg-muted text-foreground border border-border'
               end
             %>">
               <%= t("activerecord.attributes.planned_expense.status_options.#{planned_expense.status}") %>
@@ -194,12 +194,12 @@
           </div>
           
           <div class="mb-3">
-            <p class="text-2xl font-bold text-gray-900"><%= number_to_currency(planned_expense.amount) %></p>
-            <p class="text-xs text-gray-500 mt-1"><%= planned_expense.percentage_of_income.round(1) %>% of income</p>
+            <p class="text-2xl font-bold text-foreground"><%= number_to_currency(planned_expense.amount) %></p>
+            <p class="text-xs text-muted-foreground mt-1"><%= planned_expense.percentage_of_income.round(1) %>% of income</p>
           </div>
 
           <% if planned_expense.notes.present? %>
-            <div class="mb-3 p-2 bg-gray-50 rounded text-xs text-gray-600">
+            <div class="mb-3 p-2 bg-muted/35 rounded text-xs text-muted-foreground">
               <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
               </svg>
@@ -207,20 +207,20 @@
             </div>
           <% end %>
 
-          <div class="pt-3 border-t border-gray-100">
-            <%= link_to "View Details", [@income_event, planned_expense], class: "text-blue-600 hover:text-blue-800 text-sm font-medium" %>
+          <div class="pt-3 border-t border-border">
+            <%= link_to "View Details", [@income_event, planned_expense], class: "text-accent hover:text-foreground text-sm font-medium" %>
           </div>
         </div>
       <% end %>
     </div>
   <% else %>
     <!-- Empty State -->
-    <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
+    <div class="text-center py-12 bg-card rounded-xl border-2 border-dashed border-input">
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
       </svg>
-      <h3 class="mt-2 text-sm font-medium text-gray-900">No planned expenses</h3>
-      <p class="mt-1 text-sm text-gray-500">Start planning how to use this income.</p>
+      <h3 class="mt-2 text-sm font-medium text-foreground">No planned expenses</h3>
+      <p class="mt-1 text-sm text-muted-foreground">Start planning how to use this income.</p>
       <div class="mt-6">
         <%= render Ui::ButtonComponent.new(
           href: new_income_event_planned_expense_path(@income_event),
@@ -235,22 +235,22 @@
 <!-- Pending Liability Payments Section -->
 <div class="mb-6">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-2xl font-bold text-gray-900">Pending Liability Payments</h2>
-    <p class="text-sm text-gray-600">Apply payments from this income event to reduce debt balances.</p>
+    <h2 class="text-2xl font-bold text-foreground">Pending Liability Payments</h2>
+    <p class="text-sm text-muted-foreground">Apply payments from this income event to reduce debt balances.</p>
   </div>
 
   <% if @pending_liabilities.any? %>
     <div class="space-y-4">
       <% @pending_liabilities.each do |liability| %>
-        <div class="bg-white rounded-lg border border-gray-200 p-4">
+        <div class="bg-card rounded-lg border border-border p-4">
           <div class="flex flex-wrap items-center justify-between gap-3 mb-3">
             <div>
-              <h3 class="font-semibold text-gray-900"><%= liability.name %></h3>
-              <p class="text-sm text-gray-600"><%= liability.liability_type.humanize %></p>
+              <h3 class="font-semibold text-foreground"><%= liability.name %></h3>
+              <p class="text-sm text-muted-foreground"><%= liability.liability_type.humanize %></p>
             </div>
             <div class="text-right">
-              <p class="text-xs text-gray-500">Current owed</p>
-              <p class="text-lg font-bold text-red-600"><%= number_to_currency(liability.current_balance) %></p>
+              <p class="text-xs text-muted-foreground">Current owed</p>
+              <p class="text-lg font-bold text-danger"><%= number_to_currency(liability.current_balance) %></p>
             </div>
           </div>
 
@@ -258,35 +258,35 @@
             <%= hidden_field_tag "income_event_liability_payment[financial_liability_id]", liability.id %>
 
             <div class="md:col-span-2">
-              <%= label_tag "income_event_liability_payment_financial_account_id_#{liability.id}", "Pay from account", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= label_tag "income_event_liability_payment_financial_account_id_#{liability.id}", "Pay from account", class: "block text-xs font-medium text-muted-foreground mb-1" %>
               <%= select_tag "income_event_liability_payment[financial_account_id]", options_from_collection_for_select(@active_financial_accounts, :id, :name), include_blank: "Select account", class: "border rounded px-3 py-2 w-full", required: true, id: "income_event_liability_payment_financial_account_id_#{liability.id}" %>
             </div>
 
             <div>
-              <%= label_tag "income_event_liability_payment_amount_#{liability.id}", "Amount", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= label_tag "income_event_liability_payment_amount_#{liability.id}", "Amount", class: "block text-xs font-medium text-muted-foreground mb-1" %>
               <%= number_field_tag "income_event_liability_payment[amount]", liability.current_balance, step: 0.01, min: 0.01, max: liability.current_balance, class: "border rounded px-3 py-2 w-full", required: true, id: "income_event_liability_payment_amount_#{liability.id}" %>
             </div>
 
             <div>
-              <%= label_tag "income_event_liability_payment_entry_date_#{liability.id}", "Date", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= label_tag "income_event_liability_payment_entry_date_#{liability.id}", "Date", class: "block text-xs font-medium text-muted-foreground mb-1" %>
               <%= date_field_tag "income_event_liability_payment[entry_date]", Date.current, class: "border rounded px-3 py-2 w-full", required: true, id: "income_event_liability_payment_entry_date_#{liability.id}" %>
             </div>
 
             <div>
-              <%= label_tag "income_event_liability_payment_description_#{liability.id}", "Description", class: "block text-xs font-medium text-gray-600 mb-1" %>
+              <%= label_tag "income_event_liability_payment_description_#{liability.id}", "Description", class: "block text-xs font-medium text-muted-foreground mb-1" %>
               <%= text_field_tag "income_event_liability_payment[description]", "Payment to #{liability.name}", class: "border rounded px-3 py-2 w-full", id: "income_event_liability_payment_description_#{liability.id}" %>
             </div>
 
             <div class="md:col-span-5 flex justify-end">
-              <%= submit_tag "Apply payment", class: "px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700", data: { turbo_confirm: "Apply payment to #{liability.name}? Please verify source account and amount before continuing." } %>
+              <%= submit_tag "Apply payment", class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary/90", data: { turbo_confirm: "Apply payment to #{liability.name}? Please verify source account and amount before continuing." } %>
             </div>
           <% end %>
         </div>
       <% end %>
     </div>
   <% else %>
-    <div class="text-center py-8 bg-white rounded-xl border-2 border-dashed border-gray-300">
-      <p class="text-sm text-gray-500">No pending liabilities with outstanding balances.</p>
+    <div class="text-center py-8 bg-card rounded-xl border-2 border-dashed border-input">
+      <p class="text-sm text-muted-foreground">No pending liabilities with outstanding balances.</p>
     </div>
   <% end %>
 </div>
@@ -295,8 +295,8 @@
 <div class="mb-6">
   <div class="flex items-center justify-between mb-4 gap-3">
     <div>
-      <h2 class="text-2xl font-bold text-gray-900"><%= t("income_events.show.direct_expenses") %></h2>
-      <p class="text-sm text-gray-600"><%= t("income_events.show.direct_expenses_hint") %></p>
+      <h2 class="text-2xl font-bold text-foreground"><%= t("income_events.show.direct_expenses") %></h2>
+      <p class="text-sm text-muted-foreground"><%= t("income_events.show.direct_expenses_hint") %></p>
     </div>
     <%= render Ui::ButtonComponent.new(
       href: income_event_new_direct_expense_path(@income_event),
@@ -308,35 +308,35 @@
   <% if @direct_expenses.any? %>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       <% @direct_expenses.each do |expense| %>
-        <div class="bg-white rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-gray-200 p-5">
+        <div class="bg-card rounded-lg shadow-md hover:shadow-lg transition-shadow duration-200 border border-border p-5">
           <div class="flex items-start justify-between mb-3">
             <div class="flex-1">
-              <h3 class="font-semibold text-gray-900 mb-1"><%= expense.description %></h3>
-              <p class="text-sm text-gray-600"><%= expense.category.name %></p>
+              <h3 class="font-semibold text-foreground mb-1"><%= expense.description %></h3>
+              <p class="text-sm text-muted-foreground"><%= expense.category.name %></p>
             </div>
-            <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-800 border border-green-200">
+            <span class="px-2.5 py-1 rounded-full text-xs font-medium bg-success-soft text-success border border-success-soft">
               Spent
             </span>
           </div>
           
           <div class="mb-3">
-            <p class="text-2xl font-bold text-gray-900"><%= number_to_currency(expense.amount) %></p>
-            <p class="text-xs text-gray-500 mt-1"><%= expense.date.strftime("%b %d, %Y") %></p>
+            <p class="text-2xl font-bold text-foreground"><%= number_to_currency(expense.amount) %></p>
+            <p class="text-xs text-muted-foreground mt-1"><%= expense.date.strftime("%b %d, %Y") %></p>
           </div>
 
-          <div class="pt-3 border-t border-gray-100">
-            <%= link_to "View Details", expense, class: "text-blue-600 hover:text-blue-800 text-sm font-medium" %>
+          <div class="pt-3 border-t border-border">
+            <%= link_to "View Details", expense, class: "text-accent hover:text-foreground text-sm font-medium" %>
           </div>
         </div>
       <% end %>
     </div>
   <% else %>
-    <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
+    <div class="text-center py-12 bg-card rounded-xl border-2 border-dashed border-input">
       <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 1.343-3 3s1.343 3 3 3 3-1.343 3-3-1.343-3-3-3zm0 0V3m0 18v-5m9-4h-5M8 12H3"></path>
       </svg>
-      <h3 class="mt-2 text-sm font-medium text-gray-900"><%= t("income_events.show.no_direct_expenses") %></h3>
-      <p class="mt-1 text-sm text-gray-500"><%= t("income_events.show.no_direct_expenses_hint") %></p>
+      <h3 class="mt-2 text-sm font-medium text-foreground"><%= t("income_events.show.no_direct_expenses") %></h3>
+      <p class="mt-1 text-sm text-muted-foreground"><%= t("income_events.show.no_direct_expenses_hint") %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/inventory_items/_card.html.erb
+++ b/app/views/inventory_items/_card.html.erb
@@ -1,34 +1,34 @@
-<%= tag.div id: dom_id(inventory_item), class: "bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-gray-200 overflow-hidden" do %>
+<%= tag.div id: dom_id(inventory_item), class: "bg-card rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-border overflow-hidden" do %>
   <div class="p-6">
     <div class="flex flex-wrap items-center gap-3 mb-4">
       <div class="flex-shrink-0">
         <% if inventory_item.stock_state == "in_stock" %>
-          <div class="w-8 h-8 rounded-full bg-green-500" title="<%= t('inventory_items.index.in_stock') %>"></div>
+          <div class="w-8 h-8 rounded-full bg-primary" title="<%= t('inventory_items.index.in_stock') %>"></div>
         <% elsif inventory_item.stock_state == "low" %>
           <div class="w-8 h-8 rounded-full bg-yellow-500" title="<%= t('inventory_items.index.low') %>"></div>
         <% else %>
-          <div class="w-8 h-8 rounded-full bg-red-500" title="<%= t('inventory_items.index.empty_filter') %>"></div>
+          <div class="w-8 h-8 rounded-full bg-danger-soft" title="<%= t('inventory_items.index.empty_filter') %>"></div>
         <% end %>
       </div>
       <div class="flex-1 min-w-0">
-        <%= link_to inventory_item.name, inventory_item, class: "text-lg font-semibold text-gray-900 hover:text-blue-600 hover:underline" %>
-        <p class="text-sm text-gray-600 mt-0.5">
+        <%= link_to inventory_item.name, inventory_item, class: "text-lg font-semibold text-foreground hover:text-accent-dark hover:underline" %>
+        <p class="text-sm text-muted-foreground mt-0.5">
           <%= inventory_item.category&.name || t("inventory_items.index.uncategorized") %>
           <% if inventory_item.consumable? %>
-            <span class="ml-2 text-xs bg-gray-100 px-2 py-0.5 rounded"><%= t("inventory_items.form.consumable") %></span>
+            <span class="ml-2 text-xs bg-muted px-2 py-0.5 rounded"><%= t("inventory_items.form.consumable") %></span>
           <% end %>
         </p>
       </div>
     </div>
 
     <div class="mb-4">
-      <p class="text-sm font-medium text-gray-700 mb-2"><%= t("inventory_items.form.stock_state") %></p>
+      <p class="text-sm font-medium text-foreground mb-2"><%= t("inventory_items.form.stock_state") %></p>
       <div class="flex flex-wrap gap-2">
         <% %w[in_stock low empty].each do |state| %>
           <% active = inventory_item.stock_state == state %>
           <%= link_to update_stock_state_inventory_item_path(inventory_item, stock_state: state, stock_state_filter: local_assigns[:stock_filter].presence || "all", category_id: local_assigns[:category_filter]),
               data: { turbo_method: :patch },
-              class: "inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-medium transition-colors #{active ? 'ring-2 ring-offset-1 ' : ''}#{state == 'in_stock' ? (active ? 'bg-green-600 text-white ring-green-600' : 'bg-green-100 text-green-800 hover:bg-green-200') : state == 'low' ? (active ? 'bg-yellow-600 text-white ring-yellow-600' : 'bg-yellow-100 text-yellow-800 hover:bg-yellow-200') : (active ? 'bg-red-600 text-white ring-red-600' : 'bg-red-100 text-red-800 hover:bg-red-200')}" do %>
+              class: "inline-flex items-center justify-center px-4 py-2 rounded-lg text-sm font-medium transition-colors #{active ? 'ring-2 ring-offset-1 ' : ''}#{state == 'in_stock' ? (active ? 'bg-primary text-white ring-green-600' : 'bg-success-soft text-success hover:bg-green-200') : state == 'low' ? (active ? 'bg-yellow-600 text-white ring-yellow-600' : 'bg-warning-soft text-warning hover:bg-yellow-200') : (active ? 'bg-red-600 text-white ring-red-600' : 'bg-danger-soft text-danger hover:bg-red-200')}" do %>
             <%= state == "empty" ? t("inventory_items.index.empty_filter") : t("inventory_items.index.#{state}") %>
           <% end %>
         <% end %>
@@ -39,11 +39,11 @@
       <% if inventory_item.stock_state == "empty" || inventory_item.stock_state == "low" %>
         <%= link_to t("inventory_items.index.add_to_shopping_list"), add_to_shopping_list_inventory_item_path(inventory_item, stock_state: local_assigns[:stock_filter].presence, category_id: local_assigns[:category_filter]),
             data: { turbo_method: :post },
-            class: "inline-flex items-center justify-center px-4 py-2 bg-green-500 text-white text-sm rounded-lg hover:bg-green-600 transition-colors" %>
+            class: "inline-flex items-center justify-center px-4 py-2 bg-primary text-white text-sm rounded-lg hover:bg-primary/90 transition-colors" %>
       <% end %>
-      <%= link_to t("shared.view"), inventory_item, class: "inline-flex items-center justify-center px-4 py-2 bg-gray-200 text-gray-700 text-sm rounded-lg hover:bg-gray-300 transition-colors" %>
-      <%= link_to t("shared.edit"), edit_inventory_item_path(inventory_item), class: "inline-flex items-center justify-center px-4 py-2 bg-gray-200 text-gray-700 text-sm rounded-lg hover:bg-gray-300 transition-colors" %>
-      <%= button_to t("shared.delete"), inventory_item, method: :delete, params: { stock_state: local_assigns[:stock_filter].presence, category_id: local_assigns[:category_filter] }, data: { turbo_confirm: t("shared.confirm_destroy") }, class: "inline-flex items-center justify-center px-4 py-2 bg-red-500 text-white text-sm rounded-lg hover:bg-red-600 transition-colors" %>
+      <%= link_to t("shared.view"), inventory_item, class: "inline-flex items-center justify-center px-4 py-2 bg-muted text-foreground text-sm rounded-lg hover:bg-muted/80 transition-colors" %>
+      <%= link_to t("shared.edit"), edit_inventory_item_path(inventory_item), class: "inline-flex items-center justify-center px-4 py-2 bg-muted text-foreground text-sm rounded-lg hover:bg-muted/80 transition-colors" %>
+      <%= button_to t("shared.delete"), inventory_item, method: :delete, params: { stock_state: local_assigns[:stock_filter].presence, category_id: local_assigns[:category_filter] }, data: { turbo_confirm: t("shared.confirm_destroy") }, class: "inline-flex items-center justify-center px-4 py-2 bg-danger-soft text-white text-sm rounded-lg hover:bg-danger/90 transition-colors" %>
     </div>
   </div>
 <% end %>

--- a/app/views/inventory_items/_form.html.erb
+++ b/app/views/inventory_items/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @inventory_item, local: true do |form| %>
   <% if @inventory_item.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@inventory_item.errors.count, "error") %> prohibited this inventory item from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @inventory_item.errors.full_messages.each do |message| %>
@@ -11,34 +11,34 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full", required: true %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :category_id, "Category", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :category_id, @categories, :id, :name, { prompt: "Select a category (optional)" }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :stock_state, "Stock State", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :stock_state, "Stock State", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :stock_state, [["In Stock", "in_stock"], ["Low", "low"], ["Empty", "empty"]], {}, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :consumable, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :consumable, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.check_box :consumable, class: "mr-2" %>
-    <span class="text-sm text-gray-600">This item is consumable (e.g., food, toilet paper, soap)</span>
+    <span class="text-sm text-muted-foreground">This item is consumable (e.g., food, toilet paper, soap)</span>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", @inventory_item.persisted? ? @inventory_item : inventory_items_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to "Cancel", @inventory_item.persisted? ? @inventory_item : inventory_items_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/inventory_items/index.html.erb
+++ b/app/views/inventory_items/index.html.erb
@@ -12,32 +12,32 @@
 
     <div class="flex flex-wrap gap-2">
       <%= link_to t("inventory_items.index.all"), inventory_items_path(stock_state: "all", category_id: @category_filter),
-          class: "px-3 py-1.5 rounded #{@stock_filter == 'all' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@stock_filter == 'all' ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
       <%= link_to t("inventory_items.index.in_stock"), inventory_items_path(stock_state: "in_stock", category_id: @category_filter),
-          class: "px-3 py-1.5 rounded #{@stock_filter == 'in_stock' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@stock_filter == 'in_stock' ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
       <%= link_to t("inventory_items.index.low"), inventory_items_path(stock_state: "low", category_id: @category_filter),
-          class: "px-3 py-1.5 rounded #{@stock_filter == 'low' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@stock_filter == 'low' ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
       <%= link_to t("inventory_items.index.empty_filter"), inventory_items_path(stock_state: "empty", category_id: @category_filter),
-          class: "px-3 py-1.5 rounded #{@stock_filter == 'empty' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@stock_filter == 'empty' ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
     </div>
   </div>
 
   <div class="mb-4 flex flex-wrap gap-2 items-center">
     <%= link_to t("inventory_items.index.all_categories"), inventory_items_path(stock_state: @stock_filter, category_id: nil),
-        class: "px-3 py-1.5 rounded #{@category_filter.blank? ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+        class: "px-3 py-1.5 rounded #{@category_filter.blank? ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
     <% @categories_for_filter.each do |category| %>
       <%= link_to category.name, inventory_items_path(stock_state: @stock_filter, category_id: category.id),
-          class: "px-3 py-1.5 rounded #{@category_filter == category.id.to_s ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@category_filter == category.id.to_s ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
     <% end %>
     <%= link_to t("inventory_items.index.uncategorized"), inventory_items_path(stock_state: @stock_filter, category_id: "uncategorized"),
-        class: "px-3 py-1.5 rounded #{@category_filter == 'uncategorized' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+        class: "px-3 py-1.5 rounded #{@category_filter == 'uncategorized' ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
   </div>
 
   <% if @grouped_inventory_items.any? %>
     <div class="space-y-8">
       <% @grouped_inventory_items.each do |category, items| %>
         <section>
-          <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">
+          <h2 class="text-lg font-semibold text-foreground mb-3 pb-2 border-b border-border">
             <%= category ? category.name : t("inventory_items.index.uncategorized") %>
           </h2>
           <div class="space-y-4">
@@ -50,7 +50,7 @@
     </div>
   <% else %>
     <div class="text-center py-12">
-      <p class="text-gray-500"><%= t("inventory_items.index.empty") %></p>
+      <p class="text-muted-foreground"><%= t("inventory_items.index.empty") %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/inventory_items/show.html.erb
+++ b/app/views/inventory_items/show.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← Back to Inventory", inventory_items_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← Back to Inventory", inventory_items_path, class: "text-accent hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @inventory_item.name %></h1>
@@ -18,39 +18,39 @@
   <% if @inventory_item.stock_state == "empty" || @inventory_item.stock_state == "low" %>
     <%= link_to "Add to Shopping List", add_to_shopping_list_inventory_item_path(@inventory_item), 
         data: { turbo_method: :post }, 
-        class: "px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600 transition-colors" %>
+        class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary/90 transition-colors" %>
   <% end %>
 </div>
 
-<div class="bg-gray-50 p-4 rounded mb-4">
+<div class="bg-muted/35 p-4 rounded mb-4">
   <h2 class="text-xl font-semibold mb-2">Details</h2>
   <div class="grid grid-cols-2 gap-4">
     <div>
-      <p class="text-sm text-gray-600">Stock State</p>
+      <p class="text-sm text-muted-foreground">Stock State</p>
       <p class="font-semibold">
         <span class="px-2 py-1 rounded text-xs 
-          <%= @inventory_item.stock_state == 'in_stock' ? 'bg-green-100 text-green-800' : 
-              @inventory_item.stock_state == 'low' ? 'bg-yellow-100 text-yellow-800' : 
-              'bg-red-100 text-red-800' %>">
+          <%= @inventory_item.stock_state == 'in_stock' ? 'bg-success-soft text-success' : 
+              @inventory_item.stock_state == 'low' ? 'bg-warning-soft text-warning' : 
+              'bg-danger-soft text-danger' %>">
           <%= t("activerecord.attributes.inventory_item.stock_state.#{@inventory_item.stock_state}") %>
         </span>
       </p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Category</p>
+      <p class="text-sm text-muted-foreground">Category</p>
       <p class="font-semibold"><%= @inventory_item.category&.name || "-" %></p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Type</p>
+      <p class="text-sm text-muted-foreground">Type</p>
       <p class="font-semibold">
-        <span class="px-2 py-1 rounded text-xs bg-gray-100 text-gray-800">
+        <span class="px-2 py-1 rounded text-xs bg-muted text-foreground">
           <%= @inventory_item.consumable? ? "Consumable" : "Non-consumable" %>
         </span>
       </p>
     </div>
     <% if @inventory_item.notes.present? %>
       <div class="col-span-2">
-        <p class="text-sm text-gray-600">Notes</p>
+        <p class="text-sm text-muted-foreground">Notes</p>
         <p class="font-semibold"><%= @inventory_item.notes %></p>
       </div>
     <% end %>
@@ -60,7 +60,7 @@
 <div class="flex items-center gap-4 mb-4">
   <div class="flex-shrink-0">
     <% if @inventory_item.stock_state == "in_stock" %>
-      <div class="w-16 h-16 rounded-full bg-green-500 flex items-center justify-center">
+      <div class="w-16 h-16 rounded-full bg-primary flex items-center justify-center">
         <span class="text-white text-2xl">✓</span>
       </div>
     <% elsif @inventory_item.stock_state == "low" %>
@@ -68,14 +68,14 @@
         <span class="text-white text-2xl">!</span>
       </div>
     <% else %>
-      <div class="w-16 h-16 rounded-full bg-red-500 flex items-center justify-center">
+      <div class="w-16 h-16 rounded-full bg-danger-soft flex items-center justify-center">
         <span class="text-white text-2xl">×</span>
       </div>
     <% end %>
   </div>
   <div>
-    <p class="text-sm text-gray-600">Visual Indicator</p>
-    <p class="text-xs text-gray-500">Green = In Stock, Yellow = Low, Red = Empty</p>
+    <p class="text-sm text-muted-foreground">Visual Indicator</p>
+    <p class="text-xs text-muted-foreground">Green = In Stock, Yellow = Low, Red = Empty</p>
   </div>
 </div>
 

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,11 +1,11 @@
-<header class="sticky top-0 z-30 bg-gray-100 p-4 mb-6 shadow-sm" data-controller="sidebar" data-action="turbo:before-visit@window->sidebar#close">
+<header class="sticky top-0 z-30 bg-muted p-4 mb-6 shadow-sm" data-controller="sidebar" data-action="turbo:before-visit@window->sidebar#close">
   <div class="container mx-auto">
     <%# Mobile header bar: current page title + hamburger (visible only on mobile) %>
     <div class="flex justify-between items-center sm:hidden">
       <span class="font-semibold truncate max-w-[60%]" title="<%= nav_page_title %>"><%= nav_page_title %></span>
       <button
         type="button"
-        class="p-2 rounded-md text-gray-700 hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400"
+        class="p-2 rounded-md text-foreground hover:bg-muted focus:outline-none focus:ring-2 focus:ring-gray-400"
         data-sidebar-target="button"
         data-action="click->sidebar#toggle"
         data-menu-open="<%= t("nav.menu_open") %>"
@@ -22,15 +22,15 @@
     <%# Desktop nav (hidden on mobile, horizontal on sm+) %>
     <nav class="hidden sm:flex sm:flex-row justify-between items-center" aria-label="<%= t("nav.dashboard") %>">
       <div class="flex space-x-4">
-        <%= link_to t("nav.dashboard"), root_path, class: current_page?(root_path) ? "font-semibold text-gray-900" : "font-semibold text-gray-600 hover:text-gray-900" %>
-        <%= link_to t("nav.budgets"), budget_periods_path, class: controller_path == "budget_periods" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to t("nav.incomes"), income_events_path, class: controller_path == "income_events" || controller_path == "planned_expenses" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to t("nav.expenses"), expenses_path, class: controller_path == "expenses" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to "Finance", finance_path, class: controller_path.start_with?("finance") ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to t("nav.tasks"), task_root_path, class: controller_path.include?("task") ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to "Projects", projects_path, class: controller_path == "projects/projects" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to "Docs", docs_path, class: controller_path == "projects/standalone_docs" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
-        <%= link_to t("nav.reports"), reports_path, class: controller_path == "reports" ? "font-semibold text-gray-900" : "text-gray-600 hover:text-gray-900" %>
+        <%= link_to t("nav.dashboard"), root_path, class: current_page?(root_path) ? "font-semibold text-foreground" : "font-semibold text-muted-foreground hover:text-foreground" %>
+        <%= link_to t("nav.budgets"), budget_periods_path, class: controller_path == "budget_periods" ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to t("nav.incomes"), income_events_path, class: controller_path == "income_events" || controller_path == "planned_expenses" ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to t("nav.expenses"), expenses_path, class: controller_path == "expenses" ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to "Finance", finance_path, class: controller_path.start_with?("finance") ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to t("nav.tasks"), task_root_path, class: controller_path.include?("task") ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to "Projects", projects_path, class: controller_path == "projects/projects" ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to "Docs", docs_path, class: controller_path == "projects/standalone_docs" ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
+        <%= link_to t("nav.reports"), reports_path, class: controller_path == "reports" ? "font-semibold text-foreground" : "text-muted-foreground hover:text-foreground" %>
       </div>
       <div class="flex space-x-4 items-center">
         <% if authenticated? %>
@@ -46,10 +46,10 @@
                     } %>
               <% end %>
             </div>
-            <%= link_to t("nav.accounts"), accounts_path, class: "text-sm #{controller_path == "accounts" || controller_path == "account_memberships" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
+            <%= link_to t("nav.accounts"), accounts_path, class: "text-sm #{controller_path == "accounts" || controller_path == "account_memberships" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
           <% end %>
-          <%= link_to t("nav.settings"), edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), class: "text-sm #{controller_path == "settings" || controller_path == "categories" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-          <%= link_to session_path, data: { turbo_method: :delete }, class: "px-4 py-2 bg-gray-500 text-white text-sm rounded-lg hover:bg-gray-600 transition-colors" do %>
+          <%= link_to t("nav.settings"), edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), class: "text-sm #{controller_path == "settings" || controller_path == "categories" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+          <%= link_to session_path, data: { turbo_method: :delete }, class: "px-4 py-2 bg-muted text-white text-sm rounded-lg hover:bg-muted/80 transition-colors" do %>
             <%= t("nav.log_out") %>
           <% end %>
         <% end %>
@@ -66,23 +66,23 @@
   ></div>
   <aside
     data-sidebar-target="panel"
-    class="sm:hidden fixed left-0 top-0 bottom-0 w-64 bg-white shadow-xl z-50 -translate-x-full transition-transform duration-200 ease-out overflow-y-auto"
+    class="sm:hidden fixed left-0 top-0 bottom-0 w-64 bg-card shadow-xl z-50 -translate-x-full transition-transform duration-200 ease-out overflow-y-auto"
     aria-label="<%= t("nav.menu_open") %>"
   >
     <div class="p-4 flex flex-col gap-4 pt-8">
       <div class="flex flex-col gap-2">
-        <%= link_to t("nav.dashboard"), root_path, class: "py-2 #{current_page?(root_path) ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to t("nav.budgets"), budget_periods_path, class: "py-2 #{controller_path == "budget_periods" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to t("nav.incomes"), income_events_path, class: "py-2 #{controller_path == "income_events" || controller_path == "planned_expenses" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to t("nav.expenses"), expenses_path, class: "py-2 #{controller_path == "expenses" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to "Finance", finance_path, class: "py-2 #{controller_path.start_with?("finance") ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to t("nav.tasks"), task_root_path, class: "py-2 #{controller_path.include?("task") ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to "Projects", projects_path, class: "py-2 #{controller_path == "projects/projects" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to "Docs", docs_path, class: "py-2 #{controller_path == "projects/standalone_docs" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-        <%= link_to t("nav.reports"), reports_path, class: "py-2 #{controller_path == "reports" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
+        <%= link_to t("nav.dashboard"), root_path, class: "py-2 #{current_page?(root_path) ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to t("nav.budgets"), budget_periods_path, class: "py-2 #{controller_path == "budget_periods" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to t("nav.incomes"), income_events_path, class: "py-2 #{controller_path == "income_events" || controller_path == "planned_expenses" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to t("nav.expenses"), expenses_path, class: "py-2 #{controller_path == "expenses" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to "Finance", finance_path, class: "py-2 #{controller_path.start_with?("finance") ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to t("nav.tasks"), task_root_path, class: "py-2 #{controller_path.include?("task") ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to "Projects", projects_path, class: "py-2 #{controller_path == "projects/projects" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to "Docs", docs_path, class: "py-2 #{controller_path == "projects/standalone_docs" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+        <%= link_to t("nav.reports"), reports_path, class: "py-2 #{controller_path == "reports" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
       </div>
       <% if authenticated? %>
-        <hr class="border-gray-200">
+        <hr class="border-border">
         <div class="flex flex-col gap-2">
           <% if current_account %>
             <div>
@@ -96,10 +96,10 @@
                     } %>
               <% end %>
             </div>
-            <%= link_to t("nav.accounts"), accounts_path, class: "py-2 text-sm #{controller_path == "accounts" || controller_path == "account_memberships" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
+            <%= link_to t("nav.accounts"), accounts_path, class: "py-2 text-sm #{controller_path == "accounts" || controller_path == "account_memberships" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
           <% end %>
-          <%= link_to t("nav.settings"), edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), class: "py-2 text-sm #{controller_path == "settings" || controller_path == "categories" ? "font-semibold text-gray-900" : "text-gray-700 hover:text-gray-900"}" %>
-          <%= link_to session_path, data: { turbo_method: :delete }, class: "px-4 py-2 bg-gray-500 text-white text-sm rounded-lg hover:bg-gray-600 transition-colors inline-block w-fit" do %>
+          <%= link_to t("nav.settings"), edit_settings_path(section: (controller_path == "categories" ? "finance" : nil)), class: "py-2 text-sm #{controller_path == "settings" || controller_path == "categories" ? "font-semibold text-foreground" : "text-foreground hover:text-foreground"}" %>
+          <%= link_to session_path, data: { turbo_method: :delete }, class: "px-4 py-2 bg-muted text-white text-sm rounded-lg hover:bg-muted/80 transition-colors inline-block w-fit" do %>
             <%= t("nav.log_out") %>
           <% end %>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= I18n.locale %>">
+<html lang="<%= I18n.locale %>" class="<%= current_theme_palette_class %>" data-default-palette="<%= current_theme_palette %>">
   <head>
     <title><%= content_for(:title) || "Diego App" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -9,6 +9,42 @@
     <%= csp_meta_tag %>
 
     <%= yield :head %>
+
+    <script>
+      (() => {
+        try {
+          const paletteKey = "theme_palette"
+          const palettePrefix = "palette-"
+          const legacyPaletteMap = {
+            "ios-balanced": "executive-calm",
+            "ios-ocean": "ocean-depth",
+            "ios-forest": "forest-mint",
+            "ios-sunset": "sunset-ember"
+          }
+          const normalizePalette = (palette) => legacyPaletteMap[palette] || palette
+          const defaultPalette = normalizePalette(document.documentElement.dataset.defaultPalette || "executive-calm")
+          const storedPalette = normalizePalette(localStorage.getItem(paletteKey)) || defaultPalette
+
+          document.documentElement.classList.forEach((cssClass) => {
+            if (cssClass.startsWith(palettePrefix)) document.documentElement.classList.remove(cssClass)
+          })
+          document.documentElement.classList.add(`${palettePrefix}${storedPalette}`)
+          localStorage.setItem(paletteKey, storedPalette)
+
+          const storedTheme = localStorage.getItem("theme")
+          const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches
+          const useDark = storedTheme ? storedTheme === "dark" : prefersDark
+          document.documentElement.classList.toggle("dark", useDark)
+        } catch (_) {
+          // no-op: keep default light theme when storage is unavailable
+        }
+      })()
+    </script>
+
+    <!-- Load site fonts (Poppins) to match diego-blog-w-astro theme -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;700&display=swap" rel="stylesheet">
 
     <%# Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!) %>
     <%#= tag.link rel: "manifest", href: pwa_manifest_path(format: :json) %>
@@ -22,15 +58,24 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body data-controller="theme">
     <%= render SidebarProviderComponent.new do %>
       <%= render AppSidebarComponent.new(current_controller: controller_path) %>
 
-      <div data-sidebar-target="content" class="min-h-screen md:pl-[var(--sidebar-width,16rem)] transition-[padding-left] duration-200 ease-linear">
-        <header class="sticky top-0 z-30 mb-6 border-b border-sidebar-border bg-sidebar p-4 text-sidebar-foreground shadow-sm md:hidden">
+      <div data-sidebar-target="content" class="min-h-screen md:pl-[var(--sidebar-width,16rem)] transition-[padding-left] duration-200 ease-linear bg-[linear-gradient(180deg,hsl(var(--shell-gradient-start))_0%,hsl(var(--shell-gradient-end))_100%)]">
+        <header class="sticky top-0 z-30 mb-6 border-b border-sidebar-border bg-[hsl(var(--shell-main-surface))] p-3 text-sidebar-foreground shadow-sm md:hidden">
           <div class="container mx-auto flex items-center justify-between gap-4">
-            <div class="min-w-0 font-semibold truncate max-w-[60%]" title="<%= nav_page_title %>"><%= nav_page_title %></div>
-            <%= render SidebarTriggerComponent.new(variant: :menu) %>
+            <div class="min-w-0 font-semibold truncate max-w-[70%] text-sm" title="<%= nav_page_title %>"><%= nav_page_title %></div>
+            <div class="flex items-center gap-2">
+              <button
+                type="button"
+                data-action="theme#toggle"
+                class="inline-flex h-9 items-center justify-center rounded-md border border-sidebar-border px-2 text-xs font-medium text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              >
+                <span data-theme-target="label">Dark mode</span>
+              </button>
+              <%= render SidebarTriggerComponent.new(variant: :menu) %>
+            </div>
           </div>
         </header>
 
@@ -40,7 +85,16 @@
           </div>
         </div>
 
-        <%= yield %>
+        <% if Current.account.present? %>
+          <%= render QuickAddMenuComponent.new %>
+          <div id="quick-add-modal-container"></div>
+        <% end %>
+
+        <main class="mx-auto w-full max-w-7xl px-4 pt-4 pb-8">
+          <div class="rounded-3xl border border-border bg-[hsl(var(--shell-main-surface))] shadow-[var(--shell-main-shadow)] backdrop-blur-sm">
+            <%= yield %>
+          </div>
+        </main>
       </div>
     <% end %>
   </body>

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -4,15 +4,15 @@
 
   <%= form_with url: password_path(params[:token]), method: :put, class: "contents" do |form| %>
     <div class="my-5">
-      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: t("passwords.password_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: t("passwords.password_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-input focus:outline-solid focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
-      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: t("passwords.password_confirmation_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: t("passwords.password_confirmation_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-input focus:outline-solid focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="inline">
-      <%= form.submit t("passwords.save"), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+      <%= form.submit t("passwords.save"), class: "btn btn-primary w-full sm:w-auto text-center" %>
     </div>
   <% end %>
 </div>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -4,11 +4,11 @@
 
   <%= form_with url: passwords_path, class: "contents" do |form| %>
     <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: t("passwords.email_placeholder"), value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-solid focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: t("passwords.email_placeholder"), value: params[:email_address], class: "block shadow-sm rounded-md border border-input focus:outline-solid focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="inline">
-      <%= form.submit t("passwords.submit"), class: "w-full sm:w-auto text-center rounded-lg px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+      <%= form.submit t("passwords.submit"), class: "btn btn-primary w-full sm:w-auto text-center" %>
     </div>
   <% end %>
 </div>

--- a/app/views/planned_expenses/_form.html.erb
+++ b/app/views/planned_expenses/_form.html.erb
@@ -1,7 +1,7 @@
 <% templates_json = (@expense_templates || []).map { |t| { id: t.id, category_id: t.category_id, description: t.description, total_amount: t.total_amount.to_f, notes: t.notes, saved: t.total_saved.to_f } }.to_json.html_safe %>
 <%= form_with model: [@income_event, @planned_expense], local: true, class: "space-y-6", data: { controller: "template-selector", template_selector_templates_value: templates_json, template_selector_edit_mode_value: @planned_expense.persisted? } do |form| %>
   <% if @planned_expense.errors.any? %>
-    <div class="bg-red-50 border-l-4 border-red-500 text-red-700 p-4 rounded mb-6">
+    <div class="bg-danger-soft border-l-4 border-red-500 text-danger p-4 rounded mb-6">
       <div class="flex">
         <div class="flex-shrink-0">
           <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
@@ -9,10 +9,10 @@
           </svg>
         </div>
         <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">
+          <h3 class="text-sm font-medium text-danger">
             <%= @planned_expense.errors.count == 1 ? I18n.t("errors_prohibited", scope: "planned_expenses") : I18n.t("errors_prohibited_other", scope: "planned_expenses", count: @planned_expense.errors.count) %>
           </h3>
-          <ul class="mt-2 text-sm text-red-700 list-disc list-inside">
+          <ul class="mt-2 text-sm text-danger list-disc list-inside">
             <% @planned_expense.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -24,7 +24,7 @@
 
   <!-- Template Selection Section -->
   <div class="bg-gradient-to-r from-indigo-50 to-blue-50 rounded-xl p-6 border-2 border-indigo-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+    <h3 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
       <svg class="w-5 h-5 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path>
       </svg>
@@ -32,30 +32,30 @@
     </h3>
     <% if (@expense_templates || []).any? %>
       <div class="space-y-3">
-        <label class="flex items-center p-4 bg-white rounded-lg border-2 cursor-pointer hover:border-indigo-300 transition-colors <%= 'border-indigo-500' unless @planned_expense.expense_template_id.present? %>">
-          <%= radio_button_tag :use_template, "no", !@planned_expense.expense_template_id.present?, id: "use_template_no", class: "text-indigo-600 focus:ring-indigo-500", data: { action: "change->template-selector#toggle" } %>
+        <label class="flex items-center p-4 bg-card rounded-lg border-2 cursor-pointer hover:border-indigo-300 transition-colors <%= 'border-indigo-500' unless @planned_expense.expense_template_id.present? %>">
+          <%= radio_button_tag :use_template, "no", !@planned_expense.expense_template_id.present?, id: "use_template_no", class: "text-indigo-600 focus:ring-primary", data: { action: "change->template-selector#toggle" } %>
           <div class="ml-3">
-            <p class="font-medium text-gray-900">Create new planned expense</p>
-            <p class="text-sm text-gray-500">Start from scratch</p>
+            <p class="font-medium text-foreground">Create new planned expense</p>
+            <p class="text-sm text-muted-foreground">Start from scratch</p>
           </div>
         </label>
-        <label class="flex items-center p-4 bg-white rounded-lg border-2 cursor-pointer hover:border-indigo-300 transition-colors <%= 'border-indigo-500' if @planned_expense.expense_template_id.present? %>">
-          <%= radio_button_tag :use_template, "yes", @planned_expense.expense_template_id.present?, id: "use_template_yes", class: "text-indigo-600 focus:ring-indigo-500", data: { action: "change->template-selector#toggle" } %>
+        <label class="flex items-center p-4 bg-card rounded-lg border-2 cursor-pointer hover:border-indigo-300 transition-colors <%= 'border-indigo-500' if @planned_expense.expense_template_id.present? %>">
+          <%= radio_button_tag :use_template, "yes", @planned_expense.expense_template_id.present?, id: "use_template_yes", class: "text-indigo-600 focus:ring-primary", data: { action: "change->template-selector#toggle" } %>
           <div class="ml-3">
-            <p class="font-medium text-gray-900">Use template</p>
+            <p class="font-medium text-foreground">Use template</p>
             <% template_count = (@expense_templates || []).count %>
-            <p class="text-sm text-gray-500"><%= template_count == 1 ? I18n.t("existing_templates", scope: "planned_expenses.form", count: template_count) : I18n.t("existing_templates_other", scope: "planned_expenses.form", count: template_count) %></p>
+            <p class="text-sm text-muted-foreground"><%= template_count == 1 ? I18n.t("existing_templates", scope: "planned_expenses.form", count: template_count) : I18n.t("existing_templates_other", scope: "planned_expenses.form", count: template_count) %></p>
           </div>
         </label>
       </div>
       <div data-template-selector-target="selection" class="mt-4" style="<%= 'display: none;' unless @planned_expense.expense_template_id.present? %>">
-        <label class="block text-sm font-medium text-gray-700 mb-2">Select Template</label>
-        <%= form.collection_select :expense_template_id, (@expense_templates || []), :id, :name, { include_blank: "Choose a template..." }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", data: { template_selector_target: "select", action: "change->template-selector#selectTemplate" } } %>
-        <div data-template-selector-target="info" class="mt-4 p-4 bg-white rounded-lg border border-indigo-200"></div>
+        <label class="block text-sm font-medium text-foreground mb-2">Select Template</label>
+        <%= form.collection_select :expense_template_id, (@expense_templates || []), :id, :name, { include_blank: "Choose a template..." }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { template_selector_target: "select", action: "change->template-selector#selectTemplate" } } %>
+        <div data-template-selector-target="info" class="mt-4 p-4 bg-card rounded-lg border border-indigo-200"></div>
       </div>
     <% else %>
-      <div class="bg-white rounded-lg p-4 border border-indigo-200">
-        <p class="text-sm text-gray-600 mb-3">No expense templates available. Create templates to quickly add recurring expenses to your budget.</p>
+      <div class="bg-card rounded-lg p-4 border border-indigo-200">
+        <p class="text-sm text-muted-foreground mb-3">No expense templates available. Create templates to quickly add recurring expenses to your budget.</p>
         <%= link_to new_expense_template_path, class: "inline-flex items-center px-4 py-2 bg-indigo-600 text-white text-sm rounded-lg hover:bg-indigo-700 transition-colors" do %>
           <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
@@ -68,28 +68,28 @@
 
   <!-- Income Event Assignment Section -->
   <div class="bg-gradient-to-r from-purple-50 to-pink-50 rounded-xl p-6 border-2 border-purple-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+    <h3 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
       <svg class="w-5 h-5 text-purple-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
       </svg>
       Income Event Assignment
     </h3>
-    <div class="bg-white rounded-lg p-4 border border-purple-200">
-      <p class="text-sm text-gray-600 mb-3">
+    <div class="bg-card rounded-lg p-4 border border-purple-200">
+      <p class="text-sm text-muted-foreground mb-3">
         <strong>Current:</strong> <%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %> 
         (Expected: <%= @income_event.expected_date.strftime("%b %d, %Y") %>)
       </p>
       <div>
-        <%= form.label :income_event_id, "Assign to Income Event", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.collection_select :income_event_id, @income_events, :id, lambda { |ie| "#{ie.description} - #{number_to_currency(ie.expected_amount)} (Expected: #{ie.expected_date.strftime('%b %d, %Y')})" }, { selected: @income_event.id }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Change the income event to reassign this planned expense</p>
+        <%= form.label :income_event_id, "Assign to Income Event", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.collection_select :income_event_id, @income_events, :id, lambda { |ie| "#{ie.description} - #{number_to_currency(ie.expected_amount)} (Expected: #{ie.expected_date.strftime('%b %d, %Y')})" }, { selected: @income_event.id }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Change the income event to reassign this planned expense</p>
       </div>
     </div>
   </div>
 
   <!-- Financial Routing Section -->
   <div class="bg-gradient-to-r from-emerald-50 to-teal-50 rounded-xl p-6 border-2 border-emerald-200">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
+    <h3 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
       <svg class="w-5 h-5 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8V7m0 9v-1m0 1a9 9 0 100-18 9 9 0 000 18z"></path>
       </svg>
@@ -101,25 +101,25 @@
     } %>
     <% source_account_options = grouped_options_for_select(account_option_groups, @planned_expense.source_selection) %>
     <% destination_account_options = grouped_options_for_select(account_option_groups, @planned_expense.destination_selection) %>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-white rounded-lg p-4 border border-emerald-200">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 bg-card rounded-lg p-4 border border-emerald-200">
       <div>
-        <%= form.label :source_selection, "Source account", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.select :source_selection, source_account_options, { include_blank: "Select source account" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Choose the account used to pay or move the money.</p>
+        <%= form.label :source_selection, "Source account", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.select :source_selection, source_account_options, { include_blank: "Select source account" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-emerald-500 focus:ring-emerald-500" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Choose the account used to pay or move the money.</p>
       </div>
 
       <div>
-        <%= form.label :destination_selection, "Destination account", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.select :destination_selection, destination_account_options, { include_blank: "Leave blank for a normal expense" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-emerald-500 focus:ring-emerald-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Use this only for transfers or debt payments.</p>
+        <%= form.label :destination_selection, "Destination account", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.select :destination_selection, destination_account_options, { include_blank: "Leave blank for a normal expense" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-emerald-500 focus:ring-emerald-500" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Use this only for transfers or debt payments.</p>
       </div>
     </div>
   </div>
 
   <!-- Form Fields Section -->
-  <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-6 space-y-6">
-    <h3 class="text-lg font-semibold text-gray-900 mb-4 flex items-center gap-2">
-      <svg class="w-5 h-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+  <div class="bg-card rounded-xl shadow-sm border border-border p-6 space-y-6">
+    <h3 class="text-lg font-semibold text-foreground mb-4 flex items-center gap-2">
+      <svg class="w-5 h-5 text-muted-foreground" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
       </svg>
       Expense Details
@@ -127,43 +127,43 @@
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div>
-        <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.collection_select :category_id, Category.for_account(Current.account), :id, :name, { prompt: "Select a category" }, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", data: { template_selector_target: "categorySelect" } } %>
-        <p class="mt-1 text-xs text-gray-500">Choose the expense category</p>
+        <%= form.label :category_id, "Category", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.collection_select :category_id, Category.for_account(Current.account), :id, :name, { prompt: "Select a category" }, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { template_selector_target: "categorySelect" } } %>
+        <p class="mt-1 text-xs text-muted-foreground">Choose the expense category</p>
       </div>
 
       <div>
-        <%= form.label :amount, "Amount", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.label :amount, "Amount", class: "block text-sm font-medium text-foreground mb-2" %>
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span class="text-gray-500 sm:text-sm">$</span>
+            <span class="text-muted-foreground sm:text-sm">$</span>
           </div>
-          <%= form.number_field :amount, step: 0.01, class: "block w-full pl-7 rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", data: { template_selector_target: "amountField" }, placeholder: "0.00" %>
+          <%= form.number_field :amount, step: 0.01, class: "block w-full pl-7 rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { template_selector_target: "amountField" }, placeholder: "0.00" %>
         </div>
-        <p class="mt-1 text-xs text-gray-500" data-template-selector-target="amountHint"></p>
+        <p class="mt-1 text-xs text-muted-foreground" data-template-selector-target="amountHint"></p>
       </div>
 
       <div>
-        <%= form.label :due_date, "Due date", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.date_field :due_date, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" %>
+        <%= form.label :due_date, "Due date", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.date_field :due_date, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" %>
       </div>
     </div>
 
     <div>
-      <%= form.label :description, "Description", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= form.text_field :description, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", data: { template_selector_target: "descriptionField" }, placeholder: "e.g., Groceries, Rent, Utilities..." %>
-      <p class="mt-1 text-xs text-gray-500">Brief description of the expense</p>
+      <%= form.label :description, "Description", class: "block text-sm font-medium text-foreground mb-2" %>
+      <%= form.text_field :description, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { template_selector_target: "descriptionField" }, placeholder: "e.g., Groceries, Rent, Utilities..." %>
+      <p class="mt-1 text-xs text-muted-foreground">Brief description of the expense</p>
     </div>
 
     <div>
-      <%= form.label :notes, "Notes (Optional)", class: "block text-sm font-medium text-gray-700 mb-2" %>
-      <%= form.text_area :notes, rows: 3, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", data: { template_selector_target: "notesField" }, placeholder: "Additional notes or reminders..." %>
-      <p class="mt-1 text-xs text-gray-500">Add any additional information or reminders</p>
+      <%= form.label :notes, "Notes (Optional)", class: "block text-sm font-medium text-foreground mb-2" %>
+      <%= form.text_area :notes, rows: 3, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", data: { template_selector_target: "notesField" }, placeholder: "Additional notes or reminders..." %>
+      <p class="mt-1 text-xs text-muted-foreground">Add any additional information or reminders</p>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div>
-        <%= form.label :status, "Status", class: "block text-sm font-medium text-gray-700 mb-2" %>
+        <%= form.label :status, "Status", class: "block text-sm font-medium text-foreground mb-2" %>
         <%= form.select :status, [
           ['Pending to Pay', 'pending_to_pay'],
           ['Saved', 'saved'],
@@ -172,21 +172,21 @@
           ['Paid', 'paid'],
           ['Transferred', 'transferred'],
           ['Spent', 'spent']
-        ], {}, { class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500" } %>
-        <p class="mt-1 text-xs text-gray-500">Current status of this expense</p>
+        ], {}, { class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary" } %>
+        <p class="mt-1 text-xs text-muted-foreground">Current status of this expense</p>
       </div>
 
       <div>
-        <%= form.label :position, "Position (Optional)", class: "block text-sm font-medium text-gray-700 mb-2" %>
-        <%= form.number_field :position, class: "block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500", placeholder: "Auto-assigned if blank" %>
-        <p class="mt-1 text-xs text-gray-500">Order in the list (leave blank for auto-assignment)</p>
+        <%= form.label :position, "Position (Optional)", class: "block text-sm font-medium text-foreground mb-2" %>
+        <%= form.number_field :position, class: "block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary", placeholder: "Auto-assigned if blank" %>
+        <p class="mt-1 text-xs text-muted-foreground">Order in the list (leave blank for auto-assignment)</p>
       </div>
     </div>
   </div>
 
   <!-- Form Actions -->
-  <div class="flex items-center justify-end gap-4 pt-6 border-t border-gray-200">
-    <%= link_to income_event_planned_expenses_path(@income_event), class: "px-6 py-3 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors font-medium" do %>
+  <div class="flex items-center justify-end gap-4 pt-6 border-t border-border">
+    <%= link_to income_event_planned_expenses_path(@income_event), class: "px-6 py-3 border border-input rounded-lg text-foreground hover:bg-muted/35 transition-colors font-medium" do %>
       Cancel
     <% end %>
     <%= form.submit "Save Planned Expense", class: "px-6 py-3 bg-gradient-to-r from-indigo-600 to-indigo-700 text-white rounded-lg shadow-md hover:shadow-lg hover:from-indigo-700 hover:to-indigo-800 transition-all duration-200 font-medium" %>

--- a/app/views/planned_expenses/_move_form.html.erb
+++ b/app/views/planned_expenses/_move_form.html.erb
@@ -9,8 +9,8 @@ else
 end %>
 <%= form_with url: move_income_event_planned_expense_path(@income_event, planned_expense), method: :patch, local: true, class: "space-y-4" do |form| %>
   <div>
-    <label class="block text-sm font-medium text-gray-700 mb-2">Move to Income Event</label>
-    <select name="target_income_event_id" required class="block w-full rounded-lg border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+    <label class="block text-sm font-medium text-foreground mb-2">Move to Income Event</label>
+    <select name="target_income_event_id" required class="block w-full rounded-lg border-input shadow-sm focus:border-primary focus:ring-primary">
       <option value="">Select an income event...</option>
       <% ranked_income_events.each do |income_event| %>
         <% next if income_event.id == @income_event.id %>
@@ -19,11 +19,11 @@ end %>
         </option>
       <% end %>
     </select>
-    <p class="mt-1 text-xs text-gray-500">Select the income event to move this planned expense to</p>
+    <p class="mt-1 text-xs text-muted-foreground">Select the income event to move this planned expense to</p>
   </div>
   
-  <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
-    <button type="button" onclick="this.closest('[id^=\"move-modal\"]').classList.add('hidden')" class="px-4 py-2 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors">
+  <div class="flex items-center justify-end gap-3 pt-4 border-t border-border">
+    <button type="button" onclick="this.closest('[id^=\"move-modal\"]').classList.add('hidden')" class="px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 transition-colors">
       Cancel
     </button>
     <%= form.submit "Move Expense", class: "px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 transition-colors" %>

--- a/app/views/planned_expenses/edit.html.erb
+++ b/app/views/planned_expenses/edit.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-2xl font-bold mb-4">Edit Planned Expense</h1>
 
-<p class="mb-4 text-gray-600">Income Event: <%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %></p>
+<p class="mb-4 text-muted-foreground">Income Event: <%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %></p>
 
 <%= render "form", income_event: @income_event, planned_expense: @planned_expense, expense_templates: @expense_templates %>
 

--- a/app/views/planned_expenses/index.html.erb
+++ b/app/views/planned_expenses/index.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-6">
-  <%= link_to @income_event, class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+  <%= link_to @income_event, class: "inline-flex items-center text-accent hover:text-foreground transition-colors mb-4" do %>
     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
     </svg>
@@ -9,23 +9,23 @@
   <% end %>
 </div>
 
-<h1 class="text-3xl font-bold mb-6 text-gray-900">Planned Expenses</h1>
-<p class="text-gray-600 mb-8"><%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %></p>
+<h1 class="text-3xl font-bold mb-6 text-foreground">Planned Expenses</h1>
+<p class="text-muted-foreground mb-8"><%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %></p>
 
 <!-- Sticky Summary Header -->
 <div class="bg-gradient-to-r from-indigo-600 to-purple-600 rounded-xl shadow-lg p-6 mb-8 text-white sticky top-4 z-10">
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
-    <div class="bg-white/10 backdrop-blur-sm rounded-lg p-4 border border-white/20">
+    <div class="bg-card/10 backdrop-blur-sm rounded-lg p-4 border border-white/20">
       <p class="text-indigo-100 text-sm mb-1">Income Amount</p>
       <p class="text-2xl font-bold"><%= number_to_currency(@running_balance) %></p>
     </div>
-    <div class="bg-white/10 backdrop-blur-sm rounded-lg p-4 border border-white/20">
+    <div class="bg-card/10 backdrop-blur-sm rounded-lg p-4 border border-white/20">
       <p class="text-indigo-100 text-sm mb-1">Total Planned</p>
       <p class="text-2xl font-bold"><%= number_to_currency(@income_event.total_planned) %></p>
     </div>
-    <div class="bg-white/10 backdrop-blur-sm rounded-lg p-4 border border-white/20">
+    <div class="bg-card/10 backdrop-blur-sm rounded-lg p-4 border border-white/20">
       <p class="text-indigo-100 text-sm mb-1">Remaining</p>
-      <p class="text-2xl font-bold <%= @income_event.remaining_budget < 0 ? 'text-red-200' : 'text-green-200' %>">
+      <p class="text-2xl font-bold <%= @income_event.remaining_budget < 0 ? 'text-danger' : 'text-success' %>">
         <%= number_to_currency(@income_event.remaining_budget) %>
       </p>
     </div>
@@ -47,8 +47,8 @@
       <% running_total += planned_expense.amount %>
       <% available_after = @running_balance - running_total %>
       <% progress = planned_expense.template_progress %>
-      
-      <div class="bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-gray-200 overflow-hidden">
+
+      <div class="bg-card rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-border overflow-hidden">
         <div class="p-6">
           <div class="flex items-start justify-between mb-4">
             <div class="flex-1">
@@ -56,19 +56,19 @@
                 <span class="flex items-center justify-center w-8 h-8 rounded-full bg-indigo-100 text-indigo-600 font-semibold text-sm">
                   <%= planned_expense.position || (index + 1) %>
                 </span>
-                <h3 class="text-lg font-semibold text-gray-900"><%= planned_expense.description %></h3>
+                <h3 class="text-lg font-semibold text-foreground"><%= planned_expense.description %></h3>
                 <span class="px-3 py-1 rounded-full text-xs font-medium <%= 
                   case planned_expense.status
-                  when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-yellow-100 text-yellow-800 border border-yellow-200'
-                  when 'transferring' then 'bg-blue-100 text-blue-800 border border-blue-200'
-                  when 'paid', 'transferred', 'spent' then 'bg-green-100 text-green-800 border border-green-200'
-                  else 'bg-gray-100 text-gray-800 border border-gray-200'
+                  when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-warning-soft text-warning border border-warning-soft'
+                  when 'transferring' then 'bg-muted text-foreground border border-border'
+                  when 'paid', 'transferred', 'spent' then 'bg-success-soft text-success border border-success-soft'
+                  else 'bg-muted text-foreground border border-border'
                   end
                 %>">
                   <%= t("activerecord.attributes.planned_expense.status_options.#{planned_expense.status}") %>
                 </span>
               </div>
-              <div class="flex items-center gap-4 text-sm text-gray-600 ml-11">
+              <div class="flex items-center gap-4 text-sm text-muted-foreground ml-11">
                 <span class="flex items-center gap-1">
                   <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"></path>
@@ -83,14 +83,14 @@
                 </span>
               </div>
               <% if planned_expense.routing_summary.present? %>
-                <div class="ml-11 mt-3 text-sm text-gray-600">
-                  <span class="font-medium text-gray-700">Routing:</span>
+                <div class="ml-11 mt-3 text-sm text-muted-foreground">
+                  <span class="font-medium text-foreground">Routing:</span>
                   <%= planned_expense.routing_summary %>
                 </div>
               <% end %>
             </div>
             <div class="text-right">
-              <p class="text-2xl font-bold text-gray-900"><%= number_to_currency(planned_expense.amount) %></p>
+              <p class="text-2xl font-bold text-foreground"><%= number_to_currency(planned_expense.amount) %></p>
             </div>
           </div>
 
@@ -100,7 +100,7 @@
               <div class="flex items-center justify-between mb-2">
                 <%= link_to planned_expense.expense_template, class: "text-indigo-700 hover:text-indigo-900 font-medium text-sm flex items-center gap-2" do %>
                   <% if progress[:complete] %>
-                    <svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                     </svg>
                   <% end %>
@@ -122,30 +122,30 @@
 
           <!-- Notes -->
           <% if planned_expense.notes.present? %>
-            <div class="ml-11 mb-4 p-3 bg-gray-50 rounded-lg border border-gray-200">
-              <p class="text-sm text-gray-700"><%= planned_expense.notes %></p>
+            <div class="ml-11 mb-4 p-3 bg-muted/35 rounded-lg border border-border">
+              <p class="text-sm text-foreground"><%= planned_expense.notes %></p>
             </div>
           <% end %>
 
           <!-- Running Balance Visualization -->
-          <div class="ml-11 pt-4 border-t border-gray-200">
+          <div class="ml-11 pt-4 border-t border-border">
             <div class="flex items-center justify-between">
               <div class="flex items-center gap-2">
-                <svg class="w-5 h-5 <%= available_after < 0 ? 'text-red-500' : 'text-green-500' %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg class="w-5 h-5 <%= available_after < 0 ? 'text-danger' : 'text-success' %>" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
                 </svg>
-                <span class="text-sm text-gray-600">Available after this expense:</span>
+                <span class="text-sm text-muted-foreground">Available after this expense:</span>
               </div>
-              <span class="text-lg font-bold <%= available_after < 0 ? 'text-red-600' : 'text-green-600' %>">
+              <span class="text-lg font-bold <%= available_after < 0 ? 'text-danger' : 'text-success' %>">
                 <%= number_to_currency(available_after) %>
               </span>
             </div>
           </div>
 
           <!-- Actions -->
-          <div class="ml-11 mt-4 pt-4 border-t border-gray-200 flex items-center gap-3 flex-wrap">
+          <div class="ml-11 mt-4 pt-4 border-t border-border flex items-center gap-3 flex-wrap">
             <%= render Ui::ButtonComponent.new(href: edit_income_event_planned_expense_path(@income_event, planned_expense), label: "Edit", variant: "outline", size: "sm") %>
-            <button onclick="document.getElementById('move-modal-<%= planned_expense.id %>').classList.remove('hidden')" class="px-4 py-2 bg-purple-500 text-white text-sm rounded-lg hover:bg-purple-600 transition-colors">
+            <button onclick="document.getElementById('move-modal-<%= planned_expense.id %>').classList.remove('hidden')" class="btn btn-secondary">
               Move
             </button>
             <% if planned_expense.expense.nil? %>
@@ -165,13 +165,13 @@
               size: "sm"
             ) %>
           </div>
-          
+
           <!-- Move Modal for this expense -->
           <div id="move-modal-<%= planned_expense.id %>" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onclick="if(event.target === this) this.classList.add('hidden')">
-            <div class="bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4" onclick="event.stopPropagation()">
+            <div class="bg-card rounded-xl shadow-xl p-6 max-w-md w-full mx-4" onclick="event.stopPropagation()">
               <div class="flex items-center justify-between mb-4">
-                <h2 class="text-xl font-bold text-gray-900">Move Planned Expense</h2>
-                <button onclick="document.getElementById('move-modal-<%= planned_expense.id %>').classList.add('hidden')" class="text-gray-400 hover:text-gray-600">
+                <h2 class="text-xl font-bold text-foreground">Move Planned Expense</h2>
+                <button onclick="document.getElementById('move-modal-<%= planned_expense.id %>').classList.add('hidden')" class="text-gray-400 hover:text-muted-foreground">
                   <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
                   </svg>
@@ -186,12 +186,12 @@
   </div>
 <% else %>
   <!-- Empty State -->
-  <div class="text-center py-12 bg-white rounded-xl border-2 border-dashed border-gray-300">
+  <div class="text-center py-12 bg-card rounded-xl border-2 border-dashed border-input">
     <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
     </svg>
-    <h3 class="mt-2 text-sm font-medium text-gray-900">No planned expenses</h3>
-    <p class="mt-1 text-sm text-gray-500">Start planning how to allocate this income.</p>
+    <h3 class="mt-2 text-sm font-medium text-foreground">No planned expenses</h3>
+    <p class="mt-1 text-sm text-muted-foreground">Start planning how to allocate this income.</p>
     <div class="mt-6">
       <%= render Ui::ButtonComponent.new(
         href: new_income_event_planned_expense_path(@income_event),

--- a/app/views/planned_expenses/new.html.erb
+++ b/app/views/planned_expenses/new.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-2xl font-bold mb-4">New Planned Expense</h1>
 
-<p class="mb-4 text-gray-600">Income Event: <%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %></p>
+<p class="mb-4 text-muted-foreground">Income Event: <%= @income_event.description %> - <%= number_to_currency(@income_event.expected_amount) %></p>
 
 <%= render "form", income_event: @income_event, planned_expense: @planned_expense, expense_templates: @expense_templates %>
 

--- a/app/views/planned_expenses/show.html.erb
+++ b/app/views/planned_expenses/show.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
-<div class="mb-6">
-  <%= link_to income_event_planned_expenses_path(@income_event), class: "inline-flex items-center text-blue-600 hover:text-blue-800 transition-colors mb-4" do %>
+  <div class="mb-6">
+  <%= link_to income_event_planned_expenses_path(@income_event), class: "inline-flex items-center text-accent hover:text-accent-dark transition-colors mb-4" do %>
     <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
     </svg>
@@ -9,15 +9,15 @@
   <% end %>
 </div>
 
-<div class="bg-white rounded-xl shadow-md border border-gray-200 p-6 mb-6">
+<div class="bg-card rounded-xl shadow-md border border-border p-6 mb-6">
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">Planned Expense Details</h1>
+    <h1 class="text-2xl font-bold text-foreground">Planned Expense Details</h1>
     <span class="px-3 py-1 rounded-full text-xs font-medium <%= 
       case @planned_expense.status
-      when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-yellow-100 text-yellow-800 border border-yellow-200'
-      when 'transferring' then 'bg-blue-100 text-blue-800 border border-blue-200'
-      when 'paid', 'transferred', 'spent' then 'bg-green-100 text-green-800 border border-green-200'
-      else 'bg-gray-100 text-gray-800 border border-gray-200'
+      when 'pending_to_pay', 'saved', 'transfer_to_savings' then 'bg-warning-soft text-warning border border-warning-soft'
+      when 'transferring' then 'bg-muted text-foreground border border-border'
+      when 'paid', 'transferred', 'spent' then 'bg-success-soft text-success border border-success-soft'
+      else 'bg-muted text-foreground border border-border'
       end
     %>">
       <%= t("activerecord.attributes.planned_expense.status_options.#{@planned_expense.status}") %>
@@ -26,38 +26,38 @@
 
   <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
     <div>
-      <p class="text-sm font-medium text-gray-500 mb-1">Amount</p>
-      <p class="text-2xl font-bold text-gray-900"><%= number_to_currency(@planned_expense.amount) %></p>
-      <p class="text-xs text-gray-500 mt-1"><%= @planned_expense.percentage_of_income.round(1) %>% of income</p>
+      <p class="text-sm font-medium text-muted-foreground mb-1">Amount</p>
+      <p class="text-2xl font-bold text-foreground"><%= number_to_currency(@planned_expense.amount) %></p>
+      <p class="text-xs text-muted-foreground mt-1"><%= @planned_expense.percentage_of_income.round(1) %>% of income</p>
     </div>
     <div>
-      <p class="text-sm font-medium text-gray-500 mb-1">Category</p>
-      <p class="text-lg font-semibold text-gray-900"><%= @planned_expense.category.name %></p>
+      <p class="text-sm font-medium text-muted-foreground mb-1">Category</p>
+      <p class="text-lg font-semibold text-foreground"><%= @planned_expense.category.name %></p>
     </div>
     <div class="md:col-span-2">
-      <p class="text-sm font-medium text-gray-500 mb-1">Description</p>
-      <p class="text-lg text-gray-900"><%= @planned_expense.description %></p>
+      <p class="text-sm font-medium text-muted-foreground mb-1">Description</p>
+      <p class="text-lg text-foreground"><%= @planned_expense.description %></p>
     </div>
     <% if @planned_expense.notes.present? %>
       <div class="md:col-span-2">
-        <p class="text-sm font-medium text-gray-500 mb-1">Notes</p>
-        <p class="text-gray-700 bg-gray-50 p-3 rounded-lg"><%= @planned_expense.notes %></p>
+        <p class="text-sm font-medium text-muted-foreground mb-1">Notes</p>
+        <p class="text-foreground bg-muted/35 p-3 rounded-lg"><%= @planned_expense.notes %></p>
       </div>
     <% end %>
     <% if @planned_expense.routing_summary.present? %>
       <div class="md:col-span-2">
-        <p class="text-sm font-medium text-gray-500 mb-1">Routing</p>
-        <p class="text-gray-700 bg-emerald-50 p-3 rounded-lg border border-emerald-200"><%= @planned_expense.routing_summary %></p>
+        <p class="text-sm font-medium text-muted-foreground mb-1">Routing</p>
+        <p class="text-foreground bg-emerald-50 p-3 rounded-lg border border-emerald-200"><%= @planned_expense.routing_summary %></p>
       </div>
     <% end %>
     <% if @planned_expense.expense_template %>
       <div class="md:col-span-2">
-        <p class="text-sm font-medium text-gray-500 mb-1">Template</p>
+        <p class="text-sm font-medium text-muted-foreground mb-1">Template</p>
         <% progress = @planned_expense.template_progress %>
         <div class="bg-indigo-50 rounded-lg p-4 border border-indigo-200">
           <%= link_to @planned_expense.expense_template, class: "text-indigo-700 hover:text-indigo-900 font-medium flex items-center gap-2 mb-2" do %>
             <% if progress && progress[:complete] %>
-              <svg class="w-4 h-4 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg class="w-4 h-4 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
               </svg>
             <% end %>
@@ -76,9 +76,9 @@
     <% end %>
   </div>
 
-  <div class="pt-6 border-t border-gray-200 flex items-center gap-3 flex-wrap">
+    <div class="pt-6 border-t border-border flex items-center gap-3 flex-wrap">
     <%= render Ui::ButtonComponent.new(href: edit_income_event_planned_expense_path(@income_event, @planned_expense), label: "Edit", variant: "outline") %>
-    <button onclick="document.getElementById('move-modal').classList.remove('hidden')" class="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors">
+    <button onclick="document.getElementById('move-modal').classList.remove('hidden')" class="btn btn-secondary">
       Move to...
     </button>
     <% if @planned_expense.expense.nil? %>
@@ -104,17 +104,17 @@
   </div>
 </div>
 
-<div class="bg-gray-50 rounded-xl p-4 border border-gray-200">
-  <p class="text-sm text-gray-600 mb-2">Income Event</p>
-  <%= link_to @income_event.description, @income_event, class: "text-blue-600 hover:text-blue-800 font-medium" %>
+<div class="bg-muted/35 rounded-xl p-4 border border-border">
+  <p class="text-sm text-muted-foreground mb-2">Income Event</p>
+  <%= link_to @income_event.description, @income_event, class: "text-accent hover:text-foreground font-medium" %>
 </div>
 
 <!-- Move Modal -->
 <div id="move-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" onclick="if(event.target === this) this.classList.add('hidden')">
-  <div class="bg-white rounded-xl shadow-xl p-6 max-w-md w-full mx-4" onclick="event.stopPropagation()">
+  <div class="bg-card rounded-xl shadow-xl p-6 max-w-md w-full mx-4" onclick="event.stopPropagation()">
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-xl font-bold text-gray-900">Move Planned Expense</h2>
-      <button onclick="document.getElementById('move-modal').classList.add('hidden')" class="text-gray-400 hover:text-gray-600">
+      <h2 class="text-xl font-bold text-foreground">Move Planned Expense</h2>
+      <button onclick="document.getElementById('move-modal').classList.add('hidden')" class="text-gray-400 hover:text-muted-foreground">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
         </svg>
@@ -123,4 +123,3 @@
     <%= render "move_form" %>
   </div>
 </div>
-

--- a/app/views/projects/docs/edit.html.erb
+++ b/app/views/projects/docs/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Edit Document</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Edit Document</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project, @doc], url: project_doc_path(@project, @doc), method: :patch, local: true, scope: :doc do |form| %>
       <% if @doc.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @doc.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,23 +15,23 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :title, "Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :content, "Content", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :content, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 10 %>
+        <%= form.label :content, "Content", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :content, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 10 %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Update Document", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", project_path(@project), class: "px-4 py-2 border border-slate-300 rounded-lg text-slate-700 hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Update Document", class: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", project_path(@project), class: "px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/docs/index.html.erb
+++ b/app/views/projects/docs/index.html.erb
@@ -2,24 +2,24 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-3xl font-bold text-slate-900"><%= link_to @project.name, project_path(@project), class: "hover:text-blue-600" %></h1>
-        <p class="text-slate-600 mt-2">Documents</p>
+        <h1 class="text-3xl font-bold text-foreground"><%= link_to @project.name, project_path(@project), class: "hover:text-accent-dark" %></h1>
+        <p class="text-muted-foreground mt-2">Documents</p>
       </div>
       <%= render Ui::ButtonComponent.new(href: new_project_doc_path(@project), label: "New Document", variant: "default") %>
     </div>
   </div>
 
   <% if @docs.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="bg-card rounded-lg shadow overflow-hidden">
       <div class="divide-y divide-slate-200">
         <% @docs.each do |doc| %>
-          <div class="flex items-center justify-between p-4 hover:bg-slate-50 transition">
+          <div class="flex items-center justify-between p-4 hover:bg-muted/35 transition">
             <div class="flex-1">
               <div class="flex items-center gap-3">
-                <%= link_to doc.title, project_doc_path(@project, doc), class: "font-semibold text-blue-600 hover:text-blue-800" %>
+                <%= link_to doc.title, project_doc_path(@project, doc), class: "font-semibold text-accent hover:text-foreground" %>
                 <%= render StatusBadgeComponent.new(status: doc.doc_type, type: :status) %>
               </div>
-              <p class="text-sm text-slate-600 mt-1"><%= truncate(doc.content, length: 100) %></p>
+              <p class="text-sm text-muted-foreground mt-1"><%= truncate(doc.content, length: 100) %></p>
             </div>
             <div class="flex gap-2">
               <%= render Ui::ButtonComponent.new(href: project_doc_path(@project, doc), label: "View", variant: "outline") do %>
@@ -36,13 +36,13 @@
       </div>
     </div>
   <% else %>
-    <div class="bg-slate-50 rounded-lg border border-slate-200 p-8 text-center">
-      <p class="text-slate-600">No documents yet.</p>
-      <%= link_to "Create your first document", new_project_doc_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium mt-2 inline-block" %>
+    <div class="bg-slate-50 rounded-lg border border-border p-8 text-center">
+      <p class="text-muted-foreground">No documents yet.</p>
+      <%= link_to "Create your first document", new_project_doc_path(@project), class: "text-accent hover:text-foreground font-medium mt-2 inline-block" %>
     </div>
   <% end %>
 
   <div class="mt-8">
-    <%= link_to "Back to Project", project_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+    <%= link_to "Back to Project", project_path(@project), class: "text-accent hover:text-foreground font-medium" %>
   </div>
 </div>

--- a/app/views/projects/docs/new.html.erb
+++ b/app/views/projects/docs/new.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Create New Document</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Create New Document</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project, @doc], url: project_docs_path(@project), method: :post, local: true, scope: :doc do |form| %>
       <% if @doc.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @doc.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,23 +15,23 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Document title..." %>
+        <%= form.label :title, "Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", placeholder: "Document title..." %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :content, "Content", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :content, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 10, placeholder: "Document content..." %>
+        <%= form.label :content, "Content", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :content, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 10, placeholder: "Document content..." %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Create Document", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", project_path(@project), class: "px-4 py-2 border border-slate-300 rounded-lg text-slate-700 hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Create Document", class: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", project_path(@project), class: "px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/docs/show.html.erb
+++ b/app/views/projects/docs/show.html.erb
@@ -2,8 +2,8 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <p class="text-sm font-medium text-slate-600"><%= link_to @project.name, project_path(@project), class: "text-blue-600 hover:text-blue-800" %></p>
-        <h1 class="text-3xl font-bold text-slate-900 mt-1"><%= @doc.title %></h1>
+        <p class="text-sm font-medium text-muted-foreground"><%= link_to @project.name, project_path(@project), class: "text-accent hover:text-foreground" %></p>
+        <h1 class="text-3xl font-bold text-foreground mt-1"><%= @doc.title %></h1>
         <div class="flex items-center gap-3 mt-3">
           <%= render StatusBadgeComponent.new(status: @doc.doc_type, type: :status) %>
         </div>
@@ -15,63 +15,63 @@
     </div>
   </div>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <div class="markdown-content">
       <%= render_markdown(@doc.content) %>
     </div>
   </div>
 
   <!-- Links Section -->
-  <div class="mt-8 bg-white rounded-lg shadow">
-    <div class="p-6 border-b border-slate-200">
+  <div class="mt-8 bg-card rounded-lg shadow">
+    <div class="p-6 border-b border-border">
       <div class="flex items-center justify-between">
-        <h2 class="text-xl font-semibold text-slate-900"><%= t('projects.links.title') %></h2>
-        <button type="button" data-action="click->doc-links#toggleForm" class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors">
+        <h2 class="text-xl font-semibold text-foreground"><%= t('projects.links.title') %></h2>
+        <button type="button" data-action="click->doc-links#toggleForm" class="inline-flex items-center px-4 py-2 bg-primary hover:bg-primary/90 text-white text-sm font-medium rounded-md transition-colors">
           <%= t('projects.links.add_existing') %>
         </button>
       </div>
     </div>
 
     <!-- Add Existing Link Form -->
-    <div data-doc-links-target="form" class="hidden p-6 border-b border-slate-200 bg-slate-50">
+    <div data-doc-links-target="form" class="hidden p-6 border-b border-border bg-slate-50">
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-2"><%= t('projects.links.search_link') %></label>
+          <label class="block text-sm font-medium text-foreground mb-2"><%= t('projects.links.search_link') %></label>
           <input 
             type="text" 
             data-doc-links-target="search"
             data-action="input->doc-links#filterLinks"
             placeholder="<%= t('projects.links.search_placeholder') %>"
-            class="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" 
+            class="w-full px-3 py-2 border border-input rounded-md shadow-sm focus:ring-primary focus:border-primary" 
           />
         </div>
         
-        <div class="max-h-64 overflow-y-auto border border-slate-200 rounded-md bg-white">
+        <div class="max-h-64 overflow-y-auto border border-border rounded-md bg-card">
           <% if Projects::Link.for_account(Current.account).any? %>
             <% Projects::Link.for_account(Current.account).order(:title).each do |link| %>
-              <%= form_with url: doc_doc_links_path(@doc), method: :post, local: true, class: "border-b border-slate-100 last:border-0" do |f| %>
+              <%= form_with url: doc_doc_links_path(@doc), method: :post, local: true, class: "border-b border-border last:border-0" do |f| %>
                 <%= f.hidden_field :link_id, value: link.id %>
                 <button 
                   type="submit"
                   data-doc-links-target="linkItem"
                   data-link-title="<%= link.title.downcase %>"
                   data-link-url="<%= link.url.downcase %>"
-                  class="w-full text-left px-4 py-3 hover:bg-slate-50 transition-colors focus:bg-slate-100 focus:outline-none"
+                  class="w-full text-left px-4 py-3 hover:bg-muted/35 transition-colors focus:bg-slate-100 focus:outline-none"
                 >
-                  <div class="font-medium text-slate-900"><%= link.title %></div>
-                  <div class="text-xs text-slate-500 truncate"><%= link.url %></div>
-                  <div class="text-xs text-slate-400 mt-1"><%= t("projects.link_types.#{link.link_type}") %></div>
+                  <div class="font-medium text-foreground"><%= link.title %></div>
+                  <div class="text-xs text-muted-foreground truncate"><%= link.url %></div>
+                  <div class="text-xs text-muted-foreground mt-1"><%= t("projects.link_types.#{link.link_type}") %></div>
                 </button>
               <% end %>
             <% end %>
           <% else %>
-            <div class="p-4 text-sm text-slate-500 text-center">
+            <div class="p-4 text-sm text-muted-foreground text-center">
               <%= t('projects.links.no_available_links') %>
             </div>
           <% end %>
         </div>
         
-        <button type="button" data-action="click->doc-links#toggleForm" class="inline-flex items-center px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 text-sm font-medium rounded-md border border-slate-300 transition-colors">
+        <button type="button" data-action="click->doc-links#toggleForm" class="inline-flex items-center px-4 py-2 bg-card hover:bg-muted/35 text-foreground text-sm font-medium rounded-md border border-input transition-colors">
           <%= t('shared.cancel') %>
         </button>
       </div>
@@ -84,20 +84,20 @@
           <% @doc.links.each do |link| %>
             <div class="flex items-center justify-between p-4 bg-slate-50 rounded-md hover:bg-slate-100 transition-colors">
               <div class="flex-1 min-w-0">
-                <h3 class="text-sm font-semibold text-slate-900 truncate"><%= link.title %></h3>
-                <a href="<%= link.url %>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:text-blue-800 truncate block">
+                <h3 class="text-sm font-semibold text-foreground truncate"><%= link.title %></h3>
+                <a href="<%= link.url %>" target="_blank" rel="noopener noreferrer" class="text-sm text-accent hover:text-foreground truncate block">
                   <%= link.url %>
                 </a>
-                <p class="text-xs text-slate-500 mt-1"><%= t("projects.link_types.#{link.link_type}") %></p>
+                <p class="text-xs text-muted-foreground mt-1"><%= t("projects.link_types.#{link.link_type}") %></p>
               </div>
               <div class="flex items-center gap-2 ml-4">
-                <%= link_to link_path(link), class: "inline-flex items-center px-3 py-1.5 bg-white hover:bg-slate-50 text-slate-700 text-xs font-medium rounded border border-slate-300 transition-colors" do %>
+                <%= link_to link_path(link), class: "inline-flex items-center px-3 py-1.5 bg-card hover:bg-muted/35 text-foreground text-xs font-medium rounded border border-input transition-colors" do %>
                   <%= t('shared.view') %>
                 <% end %>
                 <%= button_to doc_doc_link_path(@doc, link), 
                              method: :delete, 
                              data: { turbo_confirm: t('shared.confirm_destroy') },
-                             class: "inline-flex items-center px-3 py-1.5 bg-red-50 hover:bg-red-100 text-red-700 text-xs font-medium rounded border border-red-200 transition-colors" do %>
+                             class: "inline-flex items-center px-3 py-1.5 bg-danger-soft hover:bg-danger-soft text-danger text-xs font-medium rounded border border-danger-soft transition-colors" do %>
                   <%= t('account_memberships.remove') %>
                 <% end %>
               </div>
@@ -105,17 +105,17 @@
           <% end %>
         </div>
       <% else %>
-        <p class="text-sm text-slate-500 text-center py-8"><%= t('projects.links.no_links') %></p>
+        <p class="text-sm text-muted-foreground text-center py-8"><%= t('projects.links.no_links') %></p>
       <% end %>
     </div>
 
     <!-- Create New Link -->
-    <div class="p-6 border-t border-slate-200 bg-slate-50">
-      <%= link_to t('projects.links.create_new'), new_link_path(return_to_doc_id: @doc.id, return_to_project_id: @project.id), class: "inline-flex items-center px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 text-sm font-medium rounded-md border border-slate-300 transition-colors" %>
+    <div class="p-6 border-t border-border bg-slate-50">
+      <%= link_to t('projects.links.create_new'), new_link_path(return_to_doc_id: @doc.id, return_to_project_id: @project.id), class: "inline-flex items-center px-4 py-2 bg-card hover:bg-muted/35 text-foreground text-sm font-medium rounded-md border border-input transition-colors" %>
     </div>
   </div>
 
   <div class="mt-8">
-    <%= link_to "Back to Project", project_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+    <%= link_to "Back to Project", project_path(@project), class: "text-accent hover:text-foreground font-medium" %>
   </div>
 </div>

--- a/app/views/projects/links/edit.html.erb
+++ b/app/views/projects/links/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Edit Link</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Edit Link</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project, @link], url: project_link_path(@project, @link), method: :patch, local: true, scope: :link do |form| %>
       <% if @link.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@link.errors.count, "error") %> prohibited this link from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@link.errors.count, "error") %> prohibited this link from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @link.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,28 +15,28 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :title, "Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :url, "URL", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.url_field :url, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :url, "URL", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.url_field :url, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :link_type, "Type", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.select :link_type, Projects::Link::LINK_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :link_type, "Type", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.select :link_type, Projects::Link::LINK_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :description, "Description", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :description, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 4 %>
+        <%= form.label :description, "Description", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :description, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 4 %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Update Link", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", project_path(@project), class: "px-4 py-2 border border-slate-300 rounded-lg text-slate-700 hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Update Link", class: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", project_path(@project), class: "px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/links/index.html.erb
+++ b/app/views/projects/links/index.html.erb
@@ -2,25 +2,25 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-3xl font-bold text-slate-900"><%= link_to @project.name, project_path(@project), class: "hover:text-blue-600" %></h1>
-        <p class="text-slate-600 mt-2">Links</p>
+        <h1 class="text-3xl font-bold text-foreground"><%= link_to @project.name, project_path(@project), class: "hover:text-accent-dark" %></h1>
+        <p class="text-muted-foreground mt-2">Links</p>
       </div>
       <%= render Ui::ButtonComponent.new(href: new_project_link_path(@project), label: "New Link", variant: "default") %>
     </div>
   </div>
 
   <% if @links.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="bg-card rounded-lg shadow overflow-hidden">
       <div class="divide-y divide-slate-200">
         <% @links.each do |link| %>
-          <div class="flex items-center justify-between p-4 hover:bg-slate-50 transition">
+          <div class="flex items-center justify-between p-4 hover:bg-muted/35 transition">
             <div class="flex-1">
               <div class="flex items-center gap-3">
-                <%= link_to link.title, project_link_path(@project, link), class: "font-semibold text-blue-600 hover:text-blue-800" %>
+                <%= link_to link.title, project_link_path(@project, link), class: "font-semibold text-accent hover:text-foreground" %>
                 <%= render StatusBadgeComponent.new(status: link.link_type, type: :status) %>
               </div>
-              <p class="text-sm text-slate-600 mt-1"><%= link_to link.url, link.url, target: "_blank", rel: "noopener noreferrer", class: "text-blue-600 hover:text-blue-800" %></p>
-              <p class="text-xs text-slate-500 mt-1"><%= truncate(link.description, length: 100) %></p>
+              <p class="text-sm text-muted-foreground mt-1"><%= link_to link.url, link.url, target: "_blank", rel: "noopener noreferrer", class: "text-accent hover:text-foreground" %></p>
+              <p class="text-xs text-muted-foreground mt-1"><%= truncate(link.description, length: 100) %></p>
             </div>
             <div class="flex gap-2">
               <%= render Ui::ButtonComponent.new(href: project_link_path(@project, link), label: "View", variant: "outline") do %>
@@ -37,13 +37,13 @@
       </div>
     </div>
   <% else %>
-    <div class="bg-slate-50 rounded-lg border border-slate-200 p-8 text-center">
-      <p class="text-slate-600">No links yet.</p>
-      <%= link_to "Create your first link", new_project_link_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium mt-2 inline-block" %>
+    <div class="bg-slate-50 rounded-lg border border-border p-8 text-center">
+      <p class="text-muted-foreground">No links yet.</p>
+      <%= link_to "Create your first link", new_project_link_path(@project), class: "text-accent hover:text-foreground font-medium mt-2 inline-block" %>
     </div>
   <% end %>
 
   <div class="mt-8">
-    <%= link_to "Back to Project", project_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+    <%= link_to "Back to Project", project_path(@project), class: "text-accent hover:text-foreground font-medium" %>
   </div>
 </div>

--- a/app/views/projects/links/new.html.erb
+++ b/app/views/projects/links/new.html.erb
@@ -1,18 +1,18 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Create New Link</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Create New Link</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: @link, url: @project ? project_links_path(@project) : links_path, method: :post, local: true, scope: :link do |form| %>
       <% if @link.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@link.errors.count, "error") %> prohibited this link from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@link.errors.count, "error") %> prohibited this link from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @link.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
           </ul>
           <% if @link.errors.of_kind?(:url, :taken) %>
-            <p class="mt-3 text-sm text-red-800">
+            <p class="mt-3 text-sm text-danger">
               This URL already exists in your account. Try editing the existing link or attach that existing link to this project.
             </p>
           <% end %>
@@ -23,32 +23,32 @@
       <%= form.hidden_field :return_to_project_id, value: @return_to_project_id if @return_to_project_id.present? %>
 
       <div class="mb-6">
-        <%= form.label :title, "Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Link title..." %>
+        <%= form.label :title, "Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", placeholder: "Link title..." %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :url, "URL", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.url_field :url, class: "w-full px-3 py-2 border #{ @link.errors[:url].any? ? 'border-red-400 ring-1 ring-red-200' : 'border-slate-300' } rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "https://..." %>
+        <%= form.label :url, "URL", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.url_field :url, class: "w-full px-3 py-2 border #{ @link.errors[:url].any? ? 'border-red-400 ring-1 ring-red-200' : 'border-input' } rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", placeholder: "https://..." %>
         <% if @link.errors[:url].any? %>
-          <p class="mt-2 text-sm text-red-700"><%= @link.errors[:url].to_sentence %></p>
+          <p class="mt-2 text-sm text-danger"><%= @link.errors[:url].to_sentence %></p>
         <% end %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :link_type, "Type", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.select :link_type, Projects::Link::LINK_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :link_type, "Type", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.select :link_type, Projects::Link::LINK_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :description, "Description", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :description, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 4, placeholder: "Link description..." %>
+        <%= form.label :description, "Description", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :description, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 4, placeholder: "Link description..." %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Create Link", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
+        <%= form.submit "Create Link", class: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
         <% cancel_path = @project ? project_path(@project) : (@return_to_project_id.present? && @return_to_doc_id.present? ? project_doc_path(@return_to_project_id, @return_to_doc_id) : links_path) %>
-        <%= link_to "Cancel", cancel_path, class: "px-4 py-2 border border-slate-300 rounded-lg text-slate-700 hover:bg-slate-50 font-medium" %>
+        <%= link_to "Cancel", cancel_path, class: "px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/links/show.html.erb
+++ b/app/views/projects/links/show.html.erb
@@ -2,8 +2,8 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <p class="text-sm font-medium text-slate-600"><%= link_to @project.name, project_path(@project), class: "text-blue-600 hover:text-blue-800" %></p>
-        <h1 class="text-3xl font-bold text-slate-900 mt-1"><%= @link.title %></h1>
+        <p class="text-sm font-medium text-muted-foreground"><%= link_to @project.name, project_path(@project), class: "text-accent hover:text-foreground" %></p>
+        <h1 class="text-3xl font-bold text-foreground mt-1"><%= @link.title %></h1>
         <div class="flex items-center gap-3 mt-3">
           <%= render StatusBadgeComponent.new(status: @link.link_type, type: :status) %>
         </div>
@@ -15,21 +15,21 @@
     </div>
   </div>
 
-  <div class="bg-white rounded-lg shadow p-6 mb-8">
+  <div class="bg-card rounded-lg shadow p-6 mb-8">
     <div class="mb-6">
-      <h3 class="text-sm font-semibold text-slate-600 mb-2">URL</h3>
-      <%= link_to @link.url, @link.url, target: "_blank", rel: "noopener noreferrer", class: "text-blue-600 hover:text-blue-800 break-all" %>
+      <h3 class="text-sm font-semibold text-muted-foreground mb-2">URL</h3>
+      <%= link_to @link.url, @link.url, target: "_blank", rel: "noopener noreferrer", class: "text-accent hover:text-foreground break-all" %>
     </div>
     
     <% if @link.description.present? %>
       <div>
-        <h3 class="text-sm font-semibold text-slate-600 mb-2">Description</h3>
-        <p class="text-slate-700"><%= simple_format(@link.description) %></p>
+        <h3 class="text-sm font-semibold text-muted-foreground mb-2">Description</h3>
+        <p class="text-foreground"><%= simple_format(@link.description) %></p>
       </div>
     <% end %>
   </div>
 
   <div class="mt-8">
-    <%= link_to "Back to Project", project_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+    <%= link_to "Back to Project", project_path(@project), class: "text-accent hover:text-foreground font-medium" %>
   </div>
 </div>

--- a/app/views/projects/projects/edit.html.erb
+++ b/app/views/projects/projects/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Edit Project</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Edit Project</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project], url: project_path(@project), method: :patch, local: true, scope: :project do |form| %>
       <% if @project.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@project.errors.count, "error") %> prohibited this project from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@project.errors.count, "error") %> prohibited this project from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @project.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,42 +15,42 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :name, "Project Name", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :name, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :name, "Project Name", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :name, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :summary, "Summary", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :summary, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 4 %>
+        <%= form.label :summary, "Summary", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :summary, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 4 %>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <div>
-          <%= form.label :status, "Status", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :status, Projects::Project::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :status, "Status", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :status, Projects::Project::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
         <div>
-          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :priority, Projects::Project::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :priority, Projects::Project::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <div>
-          <%= form.label :start_date, "Start Date", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.date_field :start_date, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :start_date, "Start Date", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.date_field :start_date, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
         <div>
-          <%= form.label :end_date, "End Date", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.date_field :end_date, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :end_date, "End Date", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.date_field :end_date, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Update Project", class: "px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", project_path(@project), class: "px-6 py-2 text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Update Project", class: "px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", project_path(@project), class: "px-6 py-2 text-foreground border border-input rounded-lg hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/projects/index.html.erb
+++ b/app/views/projects/projects/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container mx-auto px-4 py-8">
   <div class="mb-8">
-    <h1 class="text-3xl font-bold text-slate-900">Projects</h1>
-    <p class="text-slate-600 mt-2">Manage and track your projects</p>
+    <h1 class="text-3xl font-bold text-foreground">Projects</h1>
+    <p class="text-muted-foreground mt-2">Manage and track your projects</p>
   </div>
 
   <div class="mb-6">
@@ -9,15 +9,15 @@
   </div>
 
   <% if @projects.any? %>
-    <div class="bg-white rounded-lg shadow">
+    <div class="bg-card rounded-lg shadow">
       <% @projects.each do |project| %>
         <%= render Projects::ProjectRowComponent.new(project: project) %>
       <% end %>
     </div>
   <% else %>
-    <div class="bg-slate-50 rounded-lg border border-slate-200 p-8 text-center">
-      <p class="text-slate-600">No projects yet.</p>
-      <%= link_to "Create your first project", new_project_path, class: "text-blue-600 hover:text-blue-800 font-medium mt-2 inline-block" %>
+    <div class="bg-slate-50 rounded-lg border border-border p-8 text-center">
+      <p class="text-muted-foreground">No projects yet.</p>
+      <%= link_to "Create your first project", new_project_path, class: "text-accent hover:text-foreground font-medium mt-2 inline-block" %>
     </div>
   <% end %>
 </div>

--- a/app/views/projects/projects/new.html.erb
+++ b/app/views/projects/projects/new.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Create New Project</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Create New Project</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project], url: projects_path, method: :post, local: true, scope: :project do |form| %>
       <% if @project.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@project.errors.count, "error") %> prohibited this project from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@project.errors.count, "error") %> prohibited this project from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @project.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,42 +15,42 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :name, "Project Name", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :name, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "e.g., Q1 Product Launch" %>
+        <%= form.label :name, "Project Name", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :name, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", placeholder: "e.g., Q1 Product Launch" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :summary, "Summary", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :summary, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 4, placeholder: "Describe your project goals and scope..." %>
+        <%= form.label :summary, "Summary", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :summary, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 4, placeholder: "Describe your project goals and scope..." %>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <div>
-          <%= form.label :status, "Status", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :status, Projects::Project::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :status, "Status", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :status, Projects::Project::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
         <div>
-          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :priority, Projects::Project::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :priority, Projects::Project::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <div>
-          <%= form.label :start_date, "Start Date", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.date_field :start_date, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :start_date, "Start Date", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.date_field :start_date, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
         <div>
-          <%= form.label :end_date, "End Date", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.date_field :end_date, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :end_date, "End Date", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.date_field :end_date, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Create Project", class: "px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", projects_path, class: "px-6 py-2 text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Create Project", class: "px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", projects_path, class: "px-6 py-2 text-foreground border border-input rounded-lg hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/projects/show.html.erb
+++ b/app/views/projects/projects/show.html.erb
@@ -2,7 +2,7 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-3xl font-bold text-slate-900"><%= @project.name %></h1>
+        <h1 class="text-3xl font-bold text-foreground"><%= @project.name %></h1>
         <div class="flex items-center gap-3 mt-3">
           <%= render StatusBadgeComponent.new(status: @project.status, type: :status, translation_scope: "projects.status") %>
           <%= render StatusBadgeComponent.new(status: @project.priority, type: :priority) %>
@@ -16,23 +16,23 @@
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-sm font-semibold text-slate-600">Completion</h3>
-      <p class="text-3xl font-bold text-slate-900 mt-2"><%= @project.completion_percentage %>%</p>
+    <div class="bg-card rounded-lg shadow p-6">
+      <h3 class="text-sm font-semibold text-muted-foreground">Completion</h3>
+      <p class="text-3xl font-bold text-foreground mt-2"><%= @project.completion_percentage %>%</p>
       <div class="bg-slate-200 rounded-full h-2 mt-3 overflow-hidden">
-        <div class="bg-green-500 h-full" style="width: <%= @project.completion_percentage %>%;"></div>
+        <div class="bg-primary h-full" style="width: <%= @project.completion_percentage %>%;"></div>
       </div>
     </div>
 
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-sm font-semibold text-slate-600">Tasks</h3>
-      <p class="text-3xl font-bold text-slate-900 mt-2"><%= @tasks.count %></p>
-      <p class="text-xs text-slate-500 mt-2"><%= pluralize(@tasks.where(status: "done").count, "done") %></p>
+    <div class="bg-card rounded-lg shadow p-6">
+      <h3 class="text-sm font-semibold text-muted-foreground">Tasks</h3>
+      <p class="text-3xl font-bold text-foreground mt-2"><%= @tasks.count %></p>
+      <p class="text-xs text-muted-foreground mt-2"><%= pluralize(@tasks.where(status: "done").count, "done") %></p>
     </div>
 
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-sm font-semibold text-slate-600">Dates</h3>
-      <p class="text-sm text-slate-700 mt-2">
+    <div class="bg-card rounded-lg shadow p-6">
+      <h3 class="text-sm font-semibold text-muted-foreground">Dates</h3>
+      <p class="text-sm text-foreground mt-2">
         <% if @project.start_date %>
           From <%= @project.start_date.strftime("%b %d") %>
         <% end %>
@@ -44,18 +44,18 @@
   </div>
 
   <% if @project.summary %>
-    <div class="bg-white rounded-lg shadow p-6 mb-8">
-      <h3 class="text-lg font-semibold text-slate-900 mb-3">Summary</h3>
-      <p class="text-slate-700"><%= simple_format(@project.summary) %></p>
+    <div class="bg-card rounded-lg shadow p-6 mb-8">
+      <h3 class="text-lg font-semibold text-foreground mb-3">Summary</h3>
+      <p class="text-foreground"><%= simple_format(@project.summary) %></p>
     </div>
   <% end %>
 
-  <div class="bg-white rounded-lg shadow mb-8">
-    <div class="px-6 py-4 border-b border-slate-200">
+  <div class="bg-card rounded-lg shadow mb-8">
+    <div class="px-6 py-4 border-b border-border">
       <div class="flex items-center justify-between">
         <div>
-          <h2 class="text-lg font-semibold text-slate-900">Tasks</h2>
-          <p class="text-xs text-slate-500 mt-1">Vista: Kanban</p>
+          <h2 class="text-lg font-semibold text-foreground">Tasks</h2>
+          <p class="text-xs text-muted-foreground mt-1">Vista: Kanban</p>
         </div>
         <%= render Ui::ButtonComponent.new(href: new_project_task_path(@project), label: "New Task", variant: "default") %>
       </div>
@@ -67,31 +67,31 @@
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4 min-w-[900px]">
           <% statuses.each do |status| %>
             <% status_tasks = @tasks.select { |task| task.status == status } %>
-            <div class="bg-slate-50 rounded-lg border border-slate-200" data-kanban-target="column" data-status="<%= status %>" data-action="dragover->kanban#dragOver drop->kanban#drop">
-              <div class="px-3 py-2 border-b border-slate-200 flex items-center justify-between">
+            <div class="bg-slate-50 rounded-lg border border-border" data-kanban-target="column" data-status="<%= status %>" data-action="dragover->kanban#dragOver drop->kanban#drop">
+              <div class="px-3 py-2 border-b border-border flex items-center justify-between">
                 <div class="flex items-center gap-2">
-                  <span class="text-xs font-semibold text-slate-700"><%= t("tasks.status.#{status}") %></span>
-                  <span class="text-[10px] px-2 py-0.5 rounded-full bg-slate-200 text-slate-600" data-kanban-target="count" data-status="<%= status %>"><%= status_tasks.size %></span>
+                  <span class="text-xs font-semibold text-foreground"><%= t("tasks.status.#{status}") %></span>
+                  <span class="text-[10px] px-2 py-0.5 rounded-full bg-slate-200 text-muted-foreground" data-kanban-target="count" data-status="<%= status %>"><%= status_tasks.size %></span>
                 </div>
               </div>
 
               <div class="p-3 space-y-3">
                 <% if status_tasks.any? %>
                   <% status_tasks.each do |task| %>
-                    <div class="bg-white rounded-md border border-slate-200 p-3 shadow-sm hover:shadow transition" draggable="true" data-kanban-target="card" data-task-id="<%= task.id %>" data-task-url="<%= project_task_path(@project, task) %>" data-action="dragstart->kanban#dragStart dragend->kanban#dragEnd">
+                    <div class="bg-card rounded-md border border-border p-3 shadow-sm hover:shadow transition" draggable="true" data-kanban-target="card" data-task-id="<%= task.id %>" data-task-url="<%= project_task_path(@project, task) %>" data-action="dragstart->kanban#dragStart dragend->kanban#dragEnd">
                       <div class="flex items-start justify-between gap-2">
-                        <%= link_to task.title, project_task_path(@project, task), class: "text-sm font-semibold text-slate-900 hover:text-blue-600" %>
-                        <span class="text-[10px] font-mono text-slate-400"><%= task.task_number %></span>
+                        <%= link_to task.title, project_task_path(@project, task), class: "text-sm font-semibold text-foreground hover:text-accent-dark" %>
+                        <span class="text-[10px] font-mono text-muted-foreground"><%= task.task_number %></span>
                       </div>
                       <% if task.description.present? %>
-                        <p class="text-xs text-slate-600 mt-2"><%= truncate(task.description, length: 80) %></p>
+                        <p class="text-xs text-muted-foreground mt-2"><%= truncate(task.description, length: 80) %></p>
                       <% end %>
-                      <div class="mt-3 flex items-center justify-between text-[11px] text-slate-500">
+                      <div class="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
                         <div class="flex items-center gap-2">
                           <%= render StatusBadgeComponent.new(status: task.priority, type: :priority) %>
                         </div>
                         <% if task.due_date.present? %>
-                          <span class="<%= task.due_date < Date.current ? 'text-red-600 font-semibold' : '' %>">
+                          <span class="<%= task.due_date < Date.current ? 'text-danger font-semibold' : '' %>">
                             <%= task.due_date.strftime("%b %d") %>
                           </span>
                         <% end %>
@@ -99,7 +99,7 @@
                     </div>
                   <% end %>
                 <% else %>
-                  <div class="text-xs text-slate-500 text-center py-6">Sin tareas</div>
+                  <div class="text-xs text-muted-foreground text-center py-6">Sin tareas</div>
                 <% end %>
               </div>
             </div>
@@ -107,65 +107,65 @@
         </div>
       </div>
     <% else %>
-      <div class="p-6 text-center text-slate-600">
-        <%= link_to "Create the first task", new_project_task_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+      <div class="p-6 text-center text-muted-foreground">
+        <%= link_to "Create the first task", new_project_task_path(@project), class: "text-accent hover:text-foreground font-medium" %>
       </div>
     <% end %>
   </div>
 
-  <div class="bg-white rounded-lg shadow mb-8">
-    <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-slate-900">Documents</h2>
+  <div class="bg-card rounded-lg shadow mb-8">
+    <div class="px-6 py-4 border-b border-border flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-foreground">Documents</h2>
       <%= render Ui::ButtonComponent.new(href: new_project_doc_path(@project), label: "New Document", variant: "default") %>
     </div>
     <% if @docs.any? %>
       <div class="p-4">
         <% @docs.each do |doc| %>
-          <div class="py-2 text-sm border-b border-slate-100 last:border-0 pb-3">
-            <p class="font-medium text-blue-600"><%= link_to doc.title, project_doc_path(@project, doc) %></p>
-            <p class="text-slate-600"><%= truncate(doc.content, length: 100) %></p>
+          <div class="py-2 text-sm border-b border-border last:border-0 pb-3">
+            <p class="font-medium text-accent"><%= link_to doc.title, project_doc_path(@project, doc) %></p>
+            <p class="text-muted-foreground"><%= truncate(doc.content, length: 100) %></p>
           </div>
         <% end %>
       </div>
     <% else %>
-      <div class="p-6 text-center text-slate-600">
-        <%= link_to "Create the first document", new_project_doc_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+      <div class="p-6 text-center text-muted-foreground">
+        <%= link_to "Create the first document", new_project_doc_path(@project), class: "text-accent hover:text-foreground font-medium" %>
       </div>
     <% end %>
   </div>
 
-  <div class="bg-white rounded-lg shadow mb-8">
-    <div class="px-6 py-4 border-b border-slate-200 flex items-center justify-between">
-      <h2 class="text-lg font-semibold text-slate-900">Links</h2>
+  <div class="bg-card rounded-lg shadow mb-8">
+    <div class="px-6 py-4 border-b border-border flex items-center justify-between">
+      <h2 class="text-lg font-semibold text-foreground">Links</h2>
       <%= render Ui::ButtonComponent.new(href: new_project_link_path(@project), label: "New Link", variant: "default") %>
     </div>
     <% if @links.any? %>
       <div class="p-4">
         <% @links.each do |link| %>
-          <div class="py-2 text-sm border-b border-slate-100 last:border-0 pb-3">
-            <p class="font-medium"><%= link_to link.title, project_link_path(@project, link), class: "text-blue-600 hover:text-blue-800" %></p>
-            <p class="text-xs text-slate-500"><%= link_to link.url, link.url, target: "_blank", rel: "noopener noreferrer" %></p>
-            <p class="text-slate-600"><%= truncate(link.description, length: 100) %></p>
+          <div class="py-2 text-sm border-b border-border last:border-0 pb-3">
+            <p class="font-medium"><%= link_to link.title, project_link_path(@project, link), class: "text-accent hover:text-foreground" %></p>
+            <p class="text-xs text-muted-foreground"><%= link_to link.url, link.url, target: "_blank", rel: "noopener noreferrer" %></p>
+            <p class="text-muted-foreground"><%= truncate(link.description, length: 100) %></p>
           </div>
         <% end %>
       </div>
     <% else %>
-      <div class="p-6 text-center text-slate-600">
-        <%= link_to "Create the first link", new_project_link_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+      <div class="p-6 text-center text-muted-foreground">
+        <%= link_to "Create the first link", new_project_link_path(@project), class: "text-accent hover:text-foreground font-medium" %>
       </div>
     <% end %>
   </div>
 
   <% if @meetings.any? %>
-    <div class="bg-white rounded-lg shadow">
-      <div class="px-6 py-4 border-b border-slate-200">
-        <h2 class="text-lg font-semibold text-slate-900">Upcoming Meetings</h2>
+    <div class="bg-card rounded-lg shadow">
+      <div class="px-6 py-4 border-b border-border">
+        <h2 class="text-lg font-semibold text-foreground">Upcoming Meetings</h2>
       </div>
       <div class="p-4">
         <% @meetings.each do |meeting| %>
-          <div class="py-2 text-sm border-b border-slate-100 last:border-0">
-            <p class="font-medium text-slate-900"><%= meeting.title %></p>
-            <p class="text-slate-600"><%= meeting.start_time.strftime("%b %d, %Y at %I:%M %p") %></p>
+          <div class="py-2 text-sm border-b border-border last:border-0">
+            <p class="font-medium text-foreground"><%= meeting.title %></p>
+            <p class="text-muted-foreground"><%= meeting.start_time.strftime("%b %d, %Y at %I:%M %p") %></p>
           </div>
         <% end %>
       </div>

--- a/app/views/projects/standalone_docs/edit.html.erb
+++ b/app/views/projects/standalone_docs/edit.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Edit Document</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Edit Document</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: @doc, url: doc_path(@doc), method: :patch, local: true, scope: :doc do |form| %>
       <% if @doc.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @doc.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,23 +15,23 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :title, "Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :content, "Content (Markdown supported)", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :content, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono", rows: 15 %>
+        <%= form.label :content, "Content (Markdown supported)", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :content, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary font-mono", rows: 15 %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Update Document", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", doc_path(@doc), class: "px-4 py-2 border border-slate-300 rounded-lg text-slate-700 hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Update Document", class: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", doc_path(@doc), class: "px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/standalone_docs/index.html.erb
+++ b/app/views/projects/standalone_docs/index.html.erb
@@ -2,29 +2,29 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-3xl font-bold text-slate-900">Documents Library</h1>
-        <p class="text-slate-600 mt-2">Manage all your documents</p>
+        <h1 class="text-3xl font-bold text-foreground">Documents Library</h1>
+        <p class="text-muted-foreground mt-2">Manage all your documents</p>
       </div>
       <%= render Ui::ButtonComponent.new(href: new_doc_path, label: "New Document", variant: "default") %>
     </div>
   </div>
 
   <% if @docs.any? %>
-    <div class="bg-white rounded-lg shadow overflow-hidden">
+    <div class="bg-card rounded-lg shadow overflow-hidden">
       <div class="divide-y divide-slate-200">
         <% @docs.each do |doc| %>
-          <div class="flex items-center justify-between p-4 hover:bg-slate-50 transition">
+          <div class="flex items-center justify-between p-4 hover:bg-muted/35 transition">
             <div class="flex-1">
               <div class="flex items-center gap-3">
-                <%= link_to doc.title, doc_path(doc), class: "font-semibold text-blue-600 hover:text-blue-800" %>
+                <%= link_to doc.title, doc_path(doc), class: "font-semibold text-accent hover:text-foreground" %>
                 <%= render StatusBadgeComponent.new(status: doc.doc_type, type: :status) %>
               </div>
-              <p class="text-sm text-slate-600 mt-1"><%= truncate(doc.content, length: 100) %></p>
+              <p class="text-sm text-muted-foreground mt-1"><%= truncate(doc.content, length: 100) %></p>
               <% if doc.projects.any? %>
                 <div class="flex gap-2 mt-2">
-                  <span class="text-xs text-slate-500">Projects:</span>
+                  <span class="text-xs text-muted-foreground">Projects:</span>
                   <% doc.projects.each do |project| %>
-                    <%= link_to project.name, project_path(project), class: "text-xs text-blue-600 hover:text-blue-800" %>
+                    <%= link_to project.name, project_path(project), class: "text-xs text-accent hover:text-foreground" %>
                   <% end %>
                 </div>
               <% end %>
@@ -44,9 +44,9 @@
       </div>
     </div>
   <% else %>
-    <div class="bg-slate-50 rounded-lg border border-slate-200 p-8 text-center">
-      <p class="text-slate-600">No documents yet.</p>
-      <%= link_to "Create your first document", new_doc_path, class: "text-blue-600 hover:text-blue-800 font-medium mt-2 inline-block" %>
+    <div class="bg-slate-50 rounded-lg border border-border p-8 text-center">
+      <p class="text-muted-foreground">No documents yet.</p>
+      <%= link_to "Create your first document", new_doc_path, class: "text-accent hover:text-foreground font-medium mt-2 inline-block" %>
     </div>
   <% end %>
 </div>

--- a/app/views/projects/standalone_docs/new.html.erb
+++ b/app/views/projects/standalone_docs/new.html.erb
@@ -1,12 +1,12 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-8">Create New Document</h1>
+  <h1 class="text-3xl font-bold text-foreground mb-8">Create New Document</h1>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: @doc, url: docs_path, method: :post, local: true, scope: :doc do |form| %>
       <% if @doc.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @doc.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -15,23 +15,23 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "Document title..." %>
+        <%= form.label :title, "Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", placeholder: "Document title..." %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :doc_type, "Type", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.select :doc_type, Projects::Doc::DOC_TYPES.map { |t| [t.humanize, t] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :content, "Content (Markdown supported)", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :content, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 font-mono", rows: 15, placeholder: "# Document content\n\nWrite your content using **Markdown**..." %>
+        <%= form.label :content, "Content (Markdown supported)", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :content, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary font-mono", rows: 15, placeholder: "# Document content\n\nWrite your content using **Markdown**..." %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Create Document", class: "px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", docs_path, class: "px-4 py-2 border border-slate-300 rounded-lg text-slate-700 hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Create Document", class: "px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", docs_path, class: "px-4 py-2 border border-input rounded-lg text-foreground hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/standalone_docs/show.html.erb
+++ b/app/views/projects/standalone_docs/show.html.erb
@@ -2,7 +2,7 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <h1 class="text-3xl font-bold text-slate-900"><%= @doc.title %></h1>
+        <h1 class="text-3xl font-bold text-foreground"><%= @doc.title %></h1>
         <div class="flex items-center gap-3 mt-3">
           <%= render StatusBadgeComponent.new(status: @doc.doc_type, type: :status) %>
         </div>
@@ -14,7 +14,7 @@
     </div>
   </div>
 
-  <div class="bg-white rounded-lg shadow p-6 mb-8">
+  <div class="bg-card rounded-lg shadow p-6 mb-8">
     <div class="markdown-content">
       <%= render_markdown(@doc.content) %>
     </div>
@@ -22,17 +22,17 @@
 
   <!-- Projects using this doc -->
   <% if @doc.projects.any? %>
-    <div class="bg-white rounded-lg shadow mb-8">
-      <div class="p-6 border-b border-slate-200">
-        <h2 class="text-xl font-semibold text-slate-900">Used in Projects</h2>
+    <div class="bg-card rounded-lg shadow mb-8">
+      <div class="p-6 border-b border-border">
+        <h2 class="text-xl font-semibold text-foreground">Used in Projects</h2>
       </div>
       <div class="p-6">
         <div class="space-y-2">
           <% @doc.projects.each do |project| %>
             <div class="flex items-center justify-between p-3 bg-slate-50 rounded-md hover:bg-slate-100 transition">
               <div>
-                <%= link_to project.name, project_path(project), class: "font-medium text-blue-600 hover:text-blue-800" %>
-                <p class="text-sm text-slate-600"><%= project.summary %></p>
+                <%= link_to project.name, project_path(project), class: "font-medium text-accent hover:text-accent-dark" %>
+                <p class="text-sm text-muted-foreground"><%= project.summary %></p>
               </div>
               <%= render StatusBadgeComponent.new(status: project.status, type: :status) %>
             </div>
@@ -43,58 +43,54 @@
   <% end %>
 
   <!-- Links Section -->
-  <div class="bg-white rounded-lg shadow">
-    <div class="p-6 border-b border-slate-200">
+  <div class="bg-card rounded-lg shadow">
+    <div class="p-6 border-b border-border">
       <div class="flex items-center justify-between">
-        <h2 class="text-xl font-semibold text-slate-900"><%= t('projects.links.title') %></h2>
-        <button type="button" data-action="click->doc-links#toggleForm" class="inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md transition-colors">
-          <%= t('projects.links.add_existing') %>
-        </button>
+        <h2 class="text-xl font-semibold text-foreground"><%= t('projects.links.title') %></h2>
+        <%= render Ui::ButtonComponent.new(type: "button", label: t('projects.links.add_existing'), variant: :default, data: { action: "click->doc-links#toggleForm" }) %>
       </div>
     </div>
 
     <!-- Add Existing Link Form -->
-    <div data-doc-links-target="form" class="hidden p-6 border-b border-slate-200 bg-slate-50">
+    <div data-doc-links-target="form" class="hidden p-6 border-b border-border bg-slate-50">
       <div class="space-y-4">
         <div>
-          <label class="block text-sm font-medium text-slate-700 mb-2"><%= t('projects.links.search_link') %></label>
+          <label class="block text-sm font-medium text-foreground mb-2"><%= t('projects.links.search_link') %></label>
           <input 
             type="text" 
             data-doc-links-target="search"
             data-action="input->doc-links#filterLinks"
             placeholder="<%= t('projects.links.search_placeholder') %>"
-            class="w-full px-3 py-2 border border-slate-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" 
-          />
+            class="w-full px-3 py-2 border border-input rounded-md shadow-sm focus:ring-primary focus:border-primary" 
+>
         </div>
-        
-        <div class="max-h-64 overflow-y-auto border border-slate-200 rounded-md bg-white">
+
+        <div class="max-h-64 overflow-y-auto border border-border rounded-md bg-card">
           <% if Projects::Link.for_account(Current.account).any? %>
             <% Projects::Link.for_account(Current.account).order(:title).each do |link| %>
-              <%= form_with url: doc_doc_links_path(@doc), method: :post, local: true, class: "border-b border-slate-100 last:border-0" do |f| %>
+              <%= form_with url: doc_doc_links_path(@doc), method: :post, local: true, class: "border-b border-border last:border-0" do |f| %>
                 <%= f.hidden_field :link_id, value: link.id %>
                 <button 
                   type="submit"
                   data-doc-links-target="linkItem"
                   data-link-title="<%= link.title.downcase %>"
                   data-link-url="<%= link.url.downcase %>"
-                  class="w-full text-left px-4 py-3 hover:bg-slate-50 transition-colors focus:bg-slate-100 focus:outline-none"
+                  class="w-full text-left px-4 py-3 hover:bg-muted/35 transition-colors focus:bg-slate-100 focus:outline-none"
                 >
-                  <div class="font-medium text-slate-900"><%= link.title %></div>
-                  <div class="text-xs text-slate-500 truncate"><%= link.url %></div>
-                  <div class="text-xs text-slate-400 mt-1"><%= t("projects.link_types.#{link.link_type}") %></div>
+                  <div class="font-medium text-foreground"><%= link.title %></div>
+                  <div class="text-xs text-muted-foreground truncate"><%= link.url %></div>
+                  <div class="text-xs text-muted-foreground mt-1"><%= t("projects.link_types.#{link.link_type}") %></div>
                 </button>
               <% end %>
             <% end %>
           <% else %>
-            <div class="p-4 text-sm text-slate-500 text-center">
+            <div class="p-4 text-sm text-muted-foreground text-center">
               <%= t('projects.links.no_available_links') %>
             </div>
           <% end %>
         </div>
-        
-        <button type="button" data-action="click->doc-links#toggleForm" class="inline-flex items-center px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 text-sm font-medium rounded-md border border-slate-300 transition-colors">
-          <%= t('shared.cancel') %>
-        </button>
+
+        <%= render Ui::ButtonComponent.new(type: "button", label: t('shared.cancel'), variant: :ghost, data: { action: "click->doc-links#toggleForm" }) %>
       </div>
     </div>
 
@@ -105,20 +101,20 @@
           <% @doc.links.each do |link| %>
             <div class="flex items-center justify-between p-4 bg-slate-50 rounded-md hover:bg-slate-100 transition-colors">
               <div class="flex-1 min-w-0">
-                <h3 class="text-sm font-semibold text-slate-900 truncate"><%= link.title %></h3>
-                <a href="<%= link.url %>" target="_blank" rel="noopener noreferrer" class="text-sm text-blue-600 hover:text-blue-800 truncate block">
+                <h3 class="text-sm font-semibold text-foreground truncate"><%= link.title %></h3>
+                <a href="<%= link.url %>" target="_blank" rel="noopener noreferrer" class="text-sm text-accent hover:text-accent-dark truncate block">
                   <%= link.url %>
                 </a>
-                <p class="text-xs text-slate-500 mt-1"><%= t("projects.link_types.#{link.link_type}") %></p>
+                <p class="text-xs text-muted-foreground mt-1"><%= t("projects.link_types.#{link.link_type}") %></p>
               </div>
               <div class="flex items-center gap-2 ml-4">
-                <%= link_to link_path(link), class: "inline-flex items-center px-3 py-1.5 bg-white hover:bg-slate-50 text-slate-700 text-xs font-medium rounded border border-slate-300 transition-colors" do %>
+                <%= link_to link_path(link), class: "inline-flex items-center px-3 py-1.5 bg-card hover:bg-muted/35 text-foreground text-xs font-medium rounded border border-input transition-colors" do %>
                   <%= t('shared.view') %>
                 <% end %>
                 <%= button_to doc_doc_link_path(@doc, link), 
                              method: :delete, 
                              data: { turbo_confirm: t('shared.confirm_destroy') },
-                             class: "inline-flex items-center px-3 py-1.5 bg-red-50 hover:bg-red-100 text-red-700 text-xs font-medium rounded border border-red-200 transition-colors" do %>
+                             class: "inline-flex items-center px-3 py-1.5 bg-danger-soft hover:bg-danger-soft text-danger text-xs font-medium rounded border border-danger-soft transition-colors" do %>
                   <%= t('account_memberships.remove') %>
                 <% end %>
               </div>
@@ -126,17 +122,17 @@
           <% end %>
         </div>
       <% else %>
-        <p class="text-sm text-slate-500 text-center py-8"><%= t('projects.links.no_links') %></p>
+        <p class="text-sm text-muted-foreground text-center py-8"><%= t('projects.links.no_links') %></p>
       <% end %>
     </div>
 
     <!-- Create New Link -->
-    <div class="p-6 border-t border-slate-200 bg-slate-50">
-      <%= link_to t('projects.links.create_new'), new_link_path(return_to_doc_id: @doc.id), class: "inline-flex items-center px-4 py-2 bg-white hover:bg-slate-50 text-slate-700 text-sm font-medium rounded-md border border-slate-300 transition-colors" %>
+    <div class="p-6 border-t border-border bg-slate-50">
+      <%= link_to t('projects.links.create_new'), new_link_path(return_to_doc_id: @doc.id), class: "inline-flex items-center px-4 py-2 bg-card hover:bg-muted/35 text-foreground text-sm font-medium rounded-md border border-input transition-colors" %>
     </div>
   </div>
 
-  <div class="mt-8">
-    <%= link_to "← Back to Documents", docs_path, class: "text-blue-600 hover:text-blue-800 font-medium" %>
+    <div class="mt-8">
+    <%= link_to "← Back to Documents", docs_path, class: "text-accent hover:text-accent-dark font-medium" %>
   </div>
 </div>

--- a/app/views/projects/tasks/edit.html.erb
+++ b/app/views/projects/tasks/edit.html.erb
@@ -1,13 +1,13 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-2">Edit Task</h1>
-  <p class="text-slate-600 mb-8"><%= @task.task_number %> - for <%= link_to @project.name, project_path(@project), class: "text-blue-600 hover:text-blue-800" %></p>
+  <h1 class="text-3xl font-bold text-foreground mb-2">Edit Task</h1>
+  <p class="text-muted-foreground mb-8"><%= @task.task_number %> - for <%= link_to @project.name, project_path(@project), class: "text-accent hover:text-foreground" %></p>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project, @task], url: project_task_path(@project, @task), method: :patch, local: true, scope: :task do |form| %>
       <% if @task.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @task.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -16,35 +16,35 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Task Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :title, "Task Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :description, "Description", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :description, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 5 %>
+        <%= form.label :description, "Description", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :description, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 5 %>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <div>
-          <%= form.label :status, "Status", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :status, Projects::Task::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :status, "Status", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :status, Projects::Task::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
         <div>
-          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :priority, Projects::Task::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :priority, Projects::Task::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
       </div>
 
       <div class="mb-6">
-        <%= form.label :due_date, "Due Date", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.date_field :due_date, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :due_date, "Due Date", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.date_field :due_date, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Update Task", class: "px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", project_task_path(@project, @task), class: "px-6 py-2 text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Update Task", class: "px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", project_task_path(@project, @task), class: "px-6 py-2 text-foreground border border-input rounded-lg hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/tasks/index.html.erb
+++ b/app/views/projects/tasks/index.html.erb
@@ -1,21 +1,21 @@
 <div class="container mx-auto px-4 py-8">
   <div class="mb-8">
-    <h1 class="text-3xl font-bold text-slate-900"><%= link_to @project.name, project_path(@project), class: "hover:text-blue-600" %></h1>
-    <p class="text-slate-600 mt-2">Tasks</p>
+    <h1 class="text-3xl font-bold text-foreground"><%= link_to @project.name, project_path(@project), class: "hover:text-accent-dark" %></h1>
+    <p class="text-muted-foreground mt-2">Tasks</p>
   </div>
 
   <div class="mb-6">
     <%= render Ui::ButtonComponent.new(href: new_project_task_path(@project), label: "New Task", variant: "default") %>
   </div>
 
-  <div class="bg-white rounded-lg shadow">
+  <div class="bg-card rounded-lg shadow">
     <% if @tasks.any? %>
       <% @tasks.each do |task| %>
         <%= render Projects::TaskRowComponent.new(task: task, project: @project) %>
       <% end %>
     <% else %>
-      <div class="p-8 text-center text-slate-600">
-        <%= link_to "Create your first task", new_project_task_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+      <div class="p-8 text-center text-muted-foreground">
+        <%= link_to "Create your first task", new_project_task_path(@project), class: "text-accent hover:text-accent-dark font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/tasks/new.html.erb
+++ b/app/views/projects/tasks/new.html.erb
@@ -1,13 +1,13 @@
 <div class="container mx-auto px-4 py-8 max-w-2xl">
-  <h1 class="text-3xl font-bold text-slate-900 mb-2">Create New Task</h1>
-  <p class="text-slate-600 mb-8">for <%= link_to @project.name, project_path(@project), class: "text-blue-600 hover:text-blue-800" %></p>
+  <h1 class="text-3xl font-bold text-foreground mb-2">Create New Task</h1>
+  <p class="text-muted-foreground mb-8">for <%= link_to @project.name, project_path(@project), class: "text-accent hover:text-accent-dark" %></p>
 
-  <div class="bg-white rounded-lg shadow p-6">
+  <div class="bg-card rounded-lg shadow p-6">
     <%= form_with model: [@project, @task], url: project_tasks_path(@project), method: :post, local: true, scope: :task do |form| %>
       <% if @task.errors.any? %>
-        <div class="mb-6 bg-red-50 border border-red-200 rounded p-4">
-          <h2 class="text-sm font-semibold text-red-800 mb-2"><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
-          <ul class="text-sm text-red-700 list-disc list-inside">
+        <div class="mb-6 bg-danger-soft border border-danger-soft rounded p-4">
+          <h2 class="text-sm font-semibold text-danger mb-2"><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
+          <ul class="text-sm text-danger list-disc list-inside">
             <% @task.errors.full_messages.each do |message| %>
               <li><%= message %></li>
             <% end %>
@@ -16,35 +16,35 @@
       <% end %>
 
       <div class="mb-6">
-        <%= form.label :title, "Task Title", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_field :title, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", placeholder: "e.g., Set up authentication" %>
+        <%= form.label :title, "Task Title", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_field :title, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", placeholder: "e.g., Set up authentication" %>
       </div>
 
       <div class="mb-6">
-        <%= form.label :description, "Description", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.text_area :description, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500", rows: 5, placeholder: "Add details, notes, or instructions (supports markdown)..." %>
+        <%= form.label :description, "Description", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.text_area :description, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary", rows: 5, placeholder: "Add details, notes, or instructions (supports markdown)..." %>
       </div>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
         <div>
-          <%= form.label :status, "Status", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :status, Projects::Task::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :status, "Status", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :status, Projects::Task::STATUSES.map { |s| [s.humanize, s] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
         <div>
-          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-          <%= form.select :priority, Projects::Task::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+          <%= form.label :priority, "Priority", class: "block text-sm font-semibold text-foreground mb-2" %>
+          <%= form.select :priority, Projects::Task::PRIORITIES.map { |p| [p.humanize, p] }, {}, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
       </div>
 
       <div class="mb-6">
-        <%= form.label :due_date, "Due Date", class: "block text-sm font-semibold text-slate-700 mb-2" %>
-        <%= form.date_field :due_date, class: "w-full px-3 py-2 border border-slate-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+        <%= form.label :due_date, "Due Date", class: "block text-sm font-semibold text-foreground mb-2" %>
+        <%= form.date_field :due_date, class: "w-full px-3 py-2 border border-input rounded-lg focus:outline-none focus:ring-2 focus:ring-primary" %>
       </div>
 
       <div class="flex gap-3">
-        <%= form.submit "Create Task", class: "px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 font-medium" %>
-        <%= link_to "Cancel", project_tasks_path(@project), class: "px-6 py-2 text-slate-700 border border-slate-300 rounded-lg hover:bg-slate-50 font-medium" %>
+        <%= form.submit "Create Task", class: "px-6 py-2 bg-primary text-white rounded-lg hover:bg-primary/90 font-medium" %>
+        <%= link_to "Cancel", project_tasks_path(@project), class: "px-6 py-2 text-foreground border border-input rounded-lg hover:bg-muted/35 font-medium" %>
       </div>
     <% end %>
   </div>

--- a/app/views/projects/tasks/show.html.erb
+++ b/app/views/projects/tasks/show.html.erb
@@ -2,8 +2,8 @@
   <div class="mb-8">
     <div class="flex items-center justify-between">
       <div>
-        <p class="text-sm font-medium text-slate-600"><%= link_to @project.name, project_path(@project), class: "text-blue-600 hover:text-blue-800" %></p>
-        <h1 class="text-3xl font-bold text-slate-900 mt-1"><%= @task.task_number %> - <%= @task.title %></h1>
+        <p class="text-sm font-medium text-muted-foreground"><%= link_to @project.name, project_path(@project), class: "text-accent hover:text-accent-dark" %></p>
+        <h1 class="text-3xl font-bold text-foreground mt-1"><%= @task.task_number %> - <%= @task.title %></h1>
         <div class="flex items-center gap-3 mt-3">
           <%= render StatusBadgeComponent.new(status: @task.status, type: :status) %>
           <%= render StatusBadgeComponent.new(status: @task.priority, type: :priority) %>
@@ -17,40 +17,40 @@
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-sm font-semibold text-slate-600">Owner</h3>
-      <p class="text-lg font-bold text-slate-900 mt-2"><%= @task.user.name %></p>
+    <div class="bg-card rounded-lg shadow p-6">
+      <h3 class="text-sm font-semibold text-muted-foreground">Owner</h3>
+      <p class="text-lg font-bold text-foreground mt-2"><%= @task.user.name %></p>
     </div>
 
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-sm font-semibold text-slate-600">Status</h3>
-      <p class="text-lg font-bold text-slate-900 mt-2"><%= @task.status.humanize %></p>
+    <div class="bg-card rounded-lg shadow p-6">
+      <h3 class="text-sm font-semibold text-muted-foreground">Status</h3>
+      <p class="text-lg font-bold text-foreground mt-2"><%= @task.status.humanize %></p>
     </div>
 
-    <div class="bg-white rounded-lg shadow p-6">
-      <h3 class="text-sm font-semibold text-slate-600">Priority</h3>
-      <p class="text-lg font-bold text-slate-900 mt-2"><%= @task.priority.humanize %></p>
+    <div class="bg-card rounded-lg shadow p-6">
+      <h3 class="text-sm font-semibold text-muted-foreground">Priority</h3>
+      <p class="text-lg font-bold text-foreground mt-2"><%= @task.priority.humanize %></p>
     </div>
   </div>
 
   <% if @task.due_date %>
-    <div class="bg-white rounded-lg shadow p-6 mb-8">
-      <h3 class="text-sm font-semibold text-slate-600">Due Date</h3>
-      <p class="text-lg text-slate-900 mt-2"><%= @task.due_date.strftime("%B %d, %Y") %></p>
+    <div class="bg-card rounded-lg shadow p-6 mb-8">
+      <h3 class="text-sm font-semibold text-muted-foreground">Due Date</h3>
+      <p class="text-lg text-foreground mt-2"><%= @task.due_date.strftime("%B %d, %Y") %></p>
       <% if @task.due_date < Date.current && @task.status != "done" %>
-        <p class="text-sm text-red-600 font-semibold mt-2">Overdue</p>
+        <p class="text-sm text-danger font-semibold mt-2">Overdue</p>
       <% end %>
     </div>
   <% end %>
 
   <% if @task.description.present? %>
-    <div class="bg-white rounded-lg shadow p-6 mb-8">
-      <h3 class="text-lg font-semibold text-slate-900 mb-3">Description</h3>
-      <div class="markdown-content text-slate-700">
+    <div class="bg-card rounded-lg shadow p-6 mb-8">
+      <h3 class="text-lg font-semibold text-foreground mb-3">Description</h3>
+      <div class="markdown-content text-foreground">
         <%= render_markdown(@task.description) %>
       </div>
     </div>
   <% end %>
 
-  <%= link_to "← Back to tasks", project_tasks_path(@project), class: "text-blue-600 hover:text-blue-800 font-medium" %>
+  <%= link_to "← Back to tasks", project_tasks_path(@project), class: "text-accent hover:text-accent-dark font-medium" %>
 </div>

--- a/app/views/quick_add/doc.html.erb
+++ b/app/views/quick_add/doc.html.erb
@@ -1,25 +1,25 @@
-<div class="fixed inset-0 z-50 flex items-center justify-center md:items-end" data-controller="quick-add-menu">
-  <div class="fixed inset-0 bg-black/50" data-action="click->quick-add-menu#closeModal"></div>
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4" data-controller="quick-add-menu">
+  <div class="fixed inset-0 bg-black/50 backdrop-blur-[1px]" data-action="click->quick-add-menu#closeModal"></div>
 
-  <div class="relative w-full max-w-2xl max-h-[80vh] overflow-y-auto bg-background rounded-t-lg md:rounded-lg shadow-lg">
-    <div class="flex items-center justify-between p-4 border-b">
+  <div class="relative w-full max-w-2xl max-h-[88vh] overflow-y-auto rounded-2xl border border-border bg-card shadow-2xl">
+    <div class="flex items-start justify-between border-b border-border px-5 py-4">
       <div>
-        <h2 class="text-lg font-semibold">Create New Document</h2>
+        <h2 class="text-lg font-semibold text-foreground">Create New Document</h2>
         <p class="mt-1 text-sm text-muted-foreground">This uses the same document form as the main /docs page.</p>
       </div>
-      <button type="button" data-action="click->quick-add-menu#closeModal" class="p-1 hover:bg-accent rounded-md transition-colors">
+      <button type="button" data-action="click->quick-add-menu#closeModal" class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
     </div>
 
-    <div class="p-4">
+    <div class="p-5">
       <%= form_with model: @doc, url: docs_path, method: :post, local: false, scope: :doc, data: { turbo: true } do |form| %>
         <% if @doc.errors.any? %>
-          <div class="mb-6 rounded border border-red-200 bg-red-50 p-4">
-            <h2 class="mb-2 text-sm font-semibold text-red-800"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
-            <ul class="list-inside list-disc text-sm text-red-700">
+          <div class="mb-6 rounded border border-danger-soft bg-danger-soft p-4">
+            <h2 class="mb-2 text-sm font-semibold text-danger"><%= pluralize(@doc.errors.count, "error") %> prohibited this document from being saved:</h2>
+            <ul class="list-inside list-disc text-sm text-danger">
               <% @doc.errors.full_messages.each do |message| %>
                 <li><%= message %></li>
               <% end %>
@@ -42,9 +42,9 @@
           <%= form.text_area :content, class: "min-h-40 w-full rounded-lg border border-input bg-background px-3 py-2 font-mono text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary", rows: 15, placeholder: "# Document content\n\nWrite your content using **Markdown**..." %>
         </div>
 
-        <div class="flex gap-3">
-          <%= form.submit "Create Document", class: "rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground hover:bg-primary/90" %>
+        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <button type="button" data-action="click->quick-add-menu#closeModal" class="rounded-lg border border-input px-4 py-2 font-medium text-foreground hover:bg-accent">Cancel</button>
+          <%= form.submit "Create Document", class: "rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground hover:bg-primary/90" %>
         </div>
       <% end %>
     </div>

--- a/app/views/quick_add/financial.html.erb
+++ b/app/views/quick_add/financial.html.erb
@@ -1,19 +1,16 @@
-<div class="fixed inset-0 z-50 flex items-center justify-center md:items-end" data-controller="quick-add-menu">
-  <!-- Backdrop -->
-  <div 
-    class="fixed inset-0 bg-black/50" 
-    data-action="click->quick-add-menu#closeModal"
-  ></div>
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4" data-controller="quick-add-menu">
+  <div class="fixed inset-0 bg-black/50 backdrop-blur-[1px]" data-action="click->quick-add-menu#closeModal"></div>
 
-  <!-- Modal Content -->
-  <div class="relative w-full max-w-lg max-h-[80vh] overflow-y-auto bg-background rounded-t-lg md:rounded-lg shadow-lg md:mb-0 mb-0">
-    <!-- Header with Close Button -->
-    <div class="flex items-center justify-between p-4 border-b">
-      <h2 class="text-lg font-semibold"><%= t("quick_add.title", default: "Quick Add") %></h2>
-      <button 
+  <div class="relative w-full max-w-2xl max-h-[88vh] overflow-y-auto rounded-2xl border border-border bg-card shadow-2xl">
+    <div class="flex items-start justify-between border-b border-border px-5 py-4">
+      <div>
+        <h2 class="text-lg font-semibold text-foreground">Add money movement</h2>
+        <p class="mt-1 text-sm text-muted-foreground">Quickly record income, expense, or transfer from one place.</p>
+      </div>
+      <button
         type="button"
         data-action="click->quick-add-menu#closeModal"
-        class="p-1 hover:bg-accent rounded-md transition-colors"
+        class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -21,52 +18,47 @@
       </button>
     </div>
 
-    <!-- Modal Body -->
-    <div class="p-4">
+    <div class="p-5">
       <div data-controller="quick-add-tabs" class="space-y-4">
-        <!-- Tabs -->
-        <div class="flex gap-1 mb-4 border-b">
-          <button 
+        <div class="grid grid-cols-3 gap-2 rounded-lg border border-border bg-muted/35 p-1">
+          <button
             type="button"
             data-quick-add-tabs-target="tab"
             data-panel="income-panel"
             data-action="click->quick-add-tabs#selectTab"
-            class="px-4 py-2 font-medium text-sm bg-accent text-accent-foreground rounded-t-md"
+            class="rounded-md bg-primary px-3 py-2 text-sm font-semibold text-primary-foreground"
           >
-            💰 Income
+            Income
           </button>
-          <button 
+          <button
             type="button"
             data-quick-add-tabs-target="tab"
             data-panel="expense-panel"
             data-action="click->quick-add-tabs#selectTab"
-            class="px-4 py-2 font-medium text-sm text-muted-foreground hover:text-foreground"
+            class="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-card hover:text-foreground"
           >
-            💸 Expense
+            Expense
           </button>
-          <button 
+          <button
             type="button"
             data-quick-add-tabs-target="tab"
             data-panel="transfer-panel"
             data-action="click->quick-add-tabs#selectTab"
-            class="px-4 py-2 font-medium text-sm text-muted-foreground hover:text-foreground"
+            class="rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-card hover:text-foreground"
           >
-            ↔️ Transfer
+            Transfer
           </button>
         </div>
 
-        <!-- Income Panel -->
-        <div id="income-panel" data-quick-add-tabs-target="panel">
+        <div id="income-panel" data-quick-add-tabs-target="panel" class="space-y-4">
           <%= render "quick_add/income_form" %>
         </div>
 
-        <!-- Expense Panel -->
-        <div id="expense-panel" data-quick-add-tabs-target="panel" class="hidden">
+        <div id="expense-panel" data-quick-add-tabs-target="panel" class="hidden space-y-4">
           <%= render "quick_add/expense_form" %>
         </div>
 
-        <!-- Transfer Panel -->
-        <div id="transfer-panel" data-quick-add-tabs-target="panel" class="hidden">
+        <div id="transfer-panel" data-quick-add-tabs-target="panel" class="hidden space-y-4">
           <%= render "quick_add/transfer_form" %>
         </div>
       </div>

--- a/app/views/quick_add/task.html.erb
+++ b/app/views/quick_add/task.html.erb
@@ -1,25 +1,25 @@
-<div class="fixed inset-0 z-50 flex items-center justify-center md:items-end" data-controller="quick-add-menu">
-  <div class="fixed inset-0 bg-black/50" data-action="click->quick-add-menu#closeModal"></div>
+<div class="fixed inset-0 z-50 flex items-center justify-center p-4" data-controller="quick-add-menu">
+  <div class="fixed inset-0 bg-black/50 backdrop-blur-[1px]" data-action="click->quick-add-menu#closeModal"></div>
 
-  <div class="relative w-full max-w-2xl max-h-[80vh] overflow-y-auto bg-background rounded-t-lg md:rounded-lg shadow-lg">
-    <div class="flex items-center justify-between p-4 border-b">
+  <div class="relative w-full max-w-2xl max-h-[88vh] overflow-y-auto rounded-2xl border border-border bg-card shadow-2xl">
+    <div class="flex items-start justify-between border-b border-border px-5 py-4">
       <div>
-        <h2 class="text-lg font-semibold">Create New Task</h2>
+        <h2 class="text-lg font-semibold text-foreground">Create New Task</h2>
         <p class="mt-1 text-sm text-muted-foreground">This task starts unassigned and can be linked later.</p>
       </div>
-      <button type="button" data-action="click->quick-add-menu#closeModal" class="p-1 hover:bg-accent rounded-md transition-colors">
+      <button type="button" data-action="click->quick-add-menu#closeModal" class="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
         <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
         </svg>
       </button>
     </div>
 
-    <div class="p-4">
+    <div class="p-5">
       <%= form_with model: @task, url: quick_add_create_task_path, local: false, scope: :task, data: { turbo: true } do |form| %>
         <% if @task.errors.any? %>
-          <div class="mb-6 rounded border border-red-200 bg-red-50 p-4">
-            <h2 class="mb-2 text-sm font-semibold text-red-800"><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
-            <ul class="list-inside list-disc text-sm text-red-700">
+          <div class="mb-6 rounded border border-danger-soft bg-danger-soft p-4">
+            <h2 class="mb-2 text-sm font-semibold text-danger"><%= pluralize(@task.errors.count, "error") %> prohibited this task from being saved:</h2>
+            <ul class="list-inside list-disc text-sm text-danger">
               <% @task.errors.full_messages.each do |message| %>
                 <li><%= message %></li>
               <% end %>
@@ -54,13 +54,13 @@
           <%= form.date_field :due_date, class: "w-full rounded-lg border border-input bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary" %>
         </div>
 
-        <div class="rounded-lg border border-dashed border-input bg-muted/20 p-3 text-sm text-muted-foreground mb-6">
+        <div class="mb-6 rounded-lg border border-dashed border-input bg-muted/20 p-3 text-sm text-muted-foreground">
           This task starts unassigned. You can attach it to a project later.
         </div>
 
-        <div class="flex gap-3">
-          <%= form.submit "Create Task", class: "rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground hover:bg-primary/90" %>
+        <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <button type="button" data-action="click->quick-add-menu#closeModal" class="rounded-lg border border-input px-4 py-2 font-medium text-foreground hover:bg-accent">Cancel</button>
+          <%= form.submit "Create Task", class: "rounded-lg bg-primary px-4 py-2 font-medium text-primary-foreground hover:bg-primary/90" %>
         </div>
       <% end %>
     </div>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -3,7 +3,7 @@
   <h1 class="font-bold text-4xl"><%= t("registrations.title") %></h1>
 
   <% if @user.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= t("shared.errors_prohibited_create", count: @user.errors.count) %></h2>
       <ul class="list-disc list-inside">
         <% @user.errors.full_messages.each do |message| %>
@@ -15,28 +15,28 @@
 
   <%= form_with model: @user, url: registration_url, class: "contents" do |form| %>
     <div class="my-5">
-      <%= form.text_field :name, required: true, autofocus: true, autocomplete: "name", placeholder: t("registrations.name_placeholder"), class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.text_field :name, required: true, autofocus: true, autocomplete: "name", placeholder: t("registrations.name_placeholder"), class: "block shadow-sm rounded-md border border-input focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
-      <%= form.email_field :email_address, required: true, autocomplete: "email", placeholder: t("registrations.email_placeholder"), class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.email_field :email_address, required: true, autocomplete: "email", placeholder: t("registrations.email_placeholder"), class: "block shadow-sm rounded-md border border-input focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
-      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: t("registrations.password_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: t("registrations.password_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-input focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
-      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: t("registrations.password_confirmation_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: t("registrations.password_confirmation_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-input focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
       <div class="inline">
-        <%= form.submit t("registrations.submit"), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+        <%= form.submit t("registrations.submit"), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-primary hover:bg-primary text-white inline-block font-medium cursor-pointer" %>
       </div>
 
-      <div class="mt-4 text-sm text-gray-500 sm:mt-0">
-        <%= link_to t("registrations.sign_in_link"), new_session_path, class: "text-gray-700 underline hover:no-underline" %>
+      <div class="mt-4 text-sm text-muted-foreground sm:mt-0">
+        <%= link_to t("registrations.sign_in_link"), new_session_path, class: "text-foreground underline hover:no-underline" %>
       </div>
     </div>
   <% end %>

--- a/app/views/reports/_report_nav.html.erb
+++ b/app/views/reports/_report_nav.html.erb
@@ -10,13 +10,13 @@
   by_category_period = (current == :spending_by_category) ? period : (period || "none")
   trends_period      = (current == :category_trends) ? period : (period || "month")
 %>
-<nav class="flex flex-wrap gap-2 mb-6 py-2 border-b border-gray-200" aria-label="<%= t('reports.nav_report_types') %>">
+<nav class="flex flex-wrap gap-2 mb-6 py-2 border-b border-border" aria-label="<%= t('reports.nav_report_types') %>">
   <%= link_to t("reports.nav_overview"), reports_path(from: date_from, to: date_to),
-      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :index ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :index ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted'}" %>
   <%= link_to t("reports.by_date_title"), reports_by_date_path(from: date_from, to: date_to, period: by_date_period),
-      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :by_date ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :by_date ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted'}" %>
   <%= link_to t("reports.spending_by_category_title"), reports_spending_by_category_path(from: date_from, to: date_to, period: by_category_period),
-      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :spending_by_category ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :spending_by_category ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted'}" %>
   <%= link_to t("reports.category_trends_title"), reports_category_trends_path(from: date_from, to: date_to, period: trends_period),
-      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :category_trends ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      class: "px-4 py-2 rounded-lg text-sm font-medium transition #{current == :category_trends ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted'}" %>
 </nav>

--- a/app/views/reports/by_date.html.erb
+++ b/app/views/reports/by_date.html.erb
@@ -15,36 +15,36 @@
         params_hash: params.permit(:from, :to, :period).to_h
       ) %>
 
-  <p class="mb-6 text-sm text-gray-600">
+  <p class="mb-6 text-sm text-muted-foreground">
     <%= t("reports.summary_from_to", from: l(@date_from), to: l(@date_to)) %> · <%= t("reports.grouped_by") %>: <strong><%= t("reports.period_#{@period}") %></strong>
   </p>
 
   <% if @buckets.blank? || @buckets.all? { |b| (b[:total_expenses] || 0).zero? } %>
-    <p class="text-gray-500 py-8"><%= t("reports.empty_by_date") %></p>
+    <p class="text-muted-foreground py-8"><%= t("reports.empty_by_date") %></p>
   <% else %>
-    <section class="bg-white rounded-xl shadow-md border border-gray-200 p-4 sm:p-6 mb-6">
+    <section class="bg-card rounded-xl shadow-md border border-border p-4 sm:p-6 mb-6">
       <div class="min-h-[280px] max-w-full" style="min-height: 280px;">
         <canvas data-controller="charts" data-charts-config-value="<%= h(@chart_config.to_json) %>" style="height: 280px;"></canvas>
       </div>
     </section>
 
-    <section class="bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden">
+    <section class="bg-card rounded-xl shadow-md border border-border overflow-hidden">
       <div class="hidden md:block overflow-x-auto">
-        <table class="min-w-full divide-y divide-gray-200">
-          <thead class="bg-gray-50">
+        <table class="ui-table">
+          <thead class="bg-muted/35">
             <tr>
-              <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase"><%= t("reports.grouped_by") %></th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"><%= t("reports.total") %></th>
-              <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"><%= t("reports.view_expenses") %></th>
+              <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase"><%= t("reports.grouped_by") %></th>
+              <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase"><%= t("reports.total") %></th>
+              <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase"><%= t("reports.view_expenses") %></th>
             </tr>
           </thead>
-          <tbody class="bg-white divide-y divide-gray-200">
+          <tbody class="bg-card divide-y divide-gray-200">
             <% @buckets.each do |bucket| %>
               <tr>
-                <td class="px-4 py-3 text-sm text-gray-900"><%= bucket[:label] %></td>
+                <td class="px-4 py-3 text-sm text-foreground"><%= bucket[:label] %></td>
                 <td class="px-4 py-3 text-sm text-right font-medium"><%= number_to_currency(bucket[:total_expenses] || 0) %></td>
                 <td class="px-4 py-3 text-sm text-right">
-                  <%= link_to t("reports.view_expenses"), expenses_path(date_from: bucket[:date_from], date_to: bucket[:date_to]), class: "text-blue-600 hover:underline" %>
+                  <%= link_to t("reports.view_expenses"), expenses_path(date_from: bucket[:date_from], date_to: bucket[:date_to]), class: "text-accent hover:underline" %>
                 </td>
               </tr>
             <% end %>
@@ -55,10 +55,10 @@
         <% @buckets.each do |bucket| %>
           <div class="p-4">
             <div class="flex justify-between items-center mb-2">
-              <span class="text-sm font-medium text-gray-900"><%= bucket[:label] %></span>
+              <span class="text-sm font-medium text-foreground"><%= bucket[:label] %></span>
               <span class="text-sm font-medium"><%= number_to_currency(bucket[:total_expenses] || 0) %></span>
             </div>
-            <%= link_to t("reports.view_expenses"), expenses_path(date_from: bucket[:date_from], date_to: bucket[:date_to]), class: "inline-block py-2 px-4 text-sm text-blue-600 hover:underline" %>
+            <%= link_to t("reports.view_expenses"), expenses_path(date_from: bucket[:date_from], date_to: bucket[:date_to]), class: "inline-block py-2 px-4 text-sm text-accent hover:underline" %>
           </div>
         <% end %>
       </div>

--- a/app/views/reports/category_trends.html.erb
+++ b/app/views/reports/category_trends.html.erb
@@ -16,7 +16,7 @@
       ) %>
 
   <% if @categories_summary.blank? %>
-    <p class="text-gray-500 py-8"><%= t("reports.empty_trends") %></p>
+    <p class="text-muted-foreground py-8"><%= t("reports.empty_trends") %></p>
   <% else %>
     <%= render Ui::LineChartCardComponent.new(
           chart_config: @chart_config,
@@ -26,7 +26,7 @@
 
     <section class="rounded-xl border border-border bg-card text-card-foreground shadow-sm overflow-hidden">
       <div class="hidden md:block overflow-x-auto">
-        <table class="min-w-full divide-y divide-border">
+        <table class="ui-table">
           <thead class="bg-muted/50">
             <tr>
               <th scope="col" class="sticky left-0 bg-muted/50 z-10 px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wide"><%= t("reports.category") %></th>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -17,27 +17,27 @@
         show_period: false
       ) %>
 
-  <p class="mb-4 text-sm text-gray-600">
+  <p class="mb-4 text-sm text-muted-foreground">
     <%= t("reports.period_from") %> <strong><%= l(@date_from) %></strong> — <%= t("reports.period_to") %> <strong><%= l(@date_to) %></strong>
   </p>
 
   <div class="space-y-10 mt-8">
-    <section class="bg-white rounded-xl shadow-md border border-gray-200 p-6">
-      <h2 class="text-lg font-semibold text-gray-800 mb-4"><%= t("reports.expenses_over_time") %></h2>
+    <section class="bg-card rounded-xl shadow-md border border-border p-6">
+      <h2 class="text-lg font-semibold text-foreground mb-4"><%= t("reports.expenses_over_time") %></h2>
       <div class="min-h-[300px]">
         <canvas data-controller="charts" data-charts-config-value="<%= h(@chart_expenses_over_time.to_json) %>" style="height: 300px;"></canvas>
       </div>
     </section>
 
-    <section class="bg-white rounded-xl shadow-md border border-gray-200 p-6">
-      <h2 class="text-lg font-semibold text-gray-800 mb-4"><%= t("reports.by_category") %></h2>
+    <section class="bg-card rounded-xl shadow-md border border-border p-6">
+      <h2 class="text-lg font-semibold text-foreground mb-4"><%= t("reports.by_category") %></h2>
       <div class="min-h-[300px]">
         <canvas data-controller="charts" data-charts-config-value="<%= h(@chart_by_category.to_json) %>" style="height: 300px;"></canvas>
       </div>
     </section>
 
-    <section class="bg-white rounded-xl shadow-md border border-gray-200 p-6">
-      <h2 class="text-lg font-semibold text-gray-800 mb-4"><%= t("reports.income_vs_expenses") %></h2>
+    <section class="bg-card rounded-xl shadow-md border border-border p-6">
+      <h2 class="text-lg font-semibold text-foreground mb-4"><%= t("reports.income_vs_expenses") %></h2>
       <div class="min-h-[300px]">
         <canvas data-controller="charts" data-charts-config-value="<%= h(@chart_income_vs_expenses.to_json) %>" style="height: 300px;"></canvas>
       </div>

--- a/app/views/reports/spending_by_category.html.erb
+++ b/app/views/reports/spending_by_category.html.erb
@@ -16,32 +16,33 @@
       ) %>
 
   <% if @categories_summary.blank? %>
-    <p class="text-gray-500 py-8"><%= t("reports.empty_by_category") %></p>
+    <p class="text-muted-foreground py-8"><%= t("reports.empty_by_category") %></p>
   <% else %>
-    <section class="bg-white rounded-xl shadow-md border border-gray-200 p-4 sm:p-6 mb-6">
+    <section class="bg-card rounded-xl shadow-md border border-border p-4 sm:p-6 mb-6">
       <div class="min-h-[280px] max-w-full" style="min-height: 280px;">
         <canvas data-controller="charts" data-charts-config-value="<%= h(@chart_config.to_json) %>" style="height: 280px;"></canvas>
       </div>
     </section>
 
-    <% if @period == "none" %>
-      <section class="bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden">
+    <section class="bg-card rounded-xl shadow-md border border-border overflow-hidden">
+      <% if @period == "none" %>
+
         <div class="hidden md:block overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
+          <table class="ui-table">
+            <thead class="bg-muted/35">
               <tr>
-                <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase"><%= t("reports.category") %></th>
-                <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"><%= t("reports.total") %></th>
-                <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"><%= t("reports.view_expenses") %></th>
+                <th scope="col" class="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase"><%= t("reports.category") %></th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase"><%= t("reports.total") %></th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase"><%= t("reports.view_expenses") %></th>
               </tr>
             </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
+            <tbody class="bg-card divide-y divide-gray-200">
               <% @categories_summary.each do |cat| %>
                 <tr>
-                  <td class="px-4 py-3 text-sm text-gray-900"><%= cat[:category_name] %></td>
+                  <td class="px-4 py-3 text-sm text-foreground"><%= cat[:category_name] %></td>
                   <td class="px-4 py-3 text-sm text-right font-medium"><%= number_to_currency(cat[:total]) %></td>
                   <td class="px-4 py-3 text-sm text-right">
-                    <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "text-blue-600 hover:underline" %>
+                    <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "text-accent hover:underline hover:text-accent-dark" %>
                   </td>
                 </tr>
               <% end %>
@@ -52,37 +53,37 @@
           <% @categories_summary.each do |cat| %>
             <div class="p-4">
               <div class="flex justify-between items-center mb-2">
-                <span class="text-sm font-medium text-gray-900"><%= cat[:category_name] %></span>
+                <span class="text-sm font-medium text-foreground"><%= cat[:category_name] %></span>
                 <span class="text-sm font-medium"><%= number_to_currency(cat[:total]) %></span>
               </div>
-              <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "inline-block py-2 px-4 text-sm text-blue-600 hover:underline" %>
+              <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "inline-block py-2 px-4 text-sm text-accent hover:underline hover:text-accent-dark" %>
             </div>
           <% end %>
         </div>
-      </section>
-    <% else %>
-      <section class="bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden">
+
+      <% else %>
+
         <div class="overflow-x-auto">
-          <table class="min-w-full divide-y divide-gray-200">
-            <thead class="bg-gray-50">
+          <table class="ui-table">
+            <thead class="bg-muted/35">
               <tr>
-                <th scope="col" class="sticky left-0 bg-gray-50 z-10 px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase"><%= t("reports.category") %></th>
+                <th scope="col" class="sticky left-0 bg-muted/35 z-10 px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase"><%= t("reports.category") %></th>
                 <% @period_labels.each do |label| %>
-                  <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase whitespace-nowrap"><%= label %></th>
+                  <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase whitespace-nowrap"><%= label %></th>
                 <% end %>
-                <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase"><%= t("reports.total") %></th>
+                <th scope="col" class="px-4 py-3 text-right text-xs font-medium text-muted-foreground uppercase"><%= t("reports.total") %></th>
               </tr>
             </thead>
-            <tbody class="bg-white divide-y divide-gray-200">
+            <tbody class="bg-card divide-y divide-gray-200">
               <% @categories_summary.each do |cat| %>
                 <tr>
-                  <td class="sticky left-0 bg-white z-10 px-4 py-3 text-sm font-medium text-gray-900 border-r border-gray-200"><%= cat[:category_name] %></td>
+                  <td class="sticky left-0 bg-card z-10 px-4 py-3 text-sm font-medium text-foreground border-r border-border"><%= cat[:category_name] %></td>
                   <% @period_labels.each do |plabel| %>
                     <% bkt_data = cat[:buckets].find { |b| b[:label] == plabel } %>
                     <td class="px-4 py-3 text-sm text-right whitespace-nowrap">
                       <% if bkt_data %>
                         <%= number_to_currency(bkt_data[:amount]) %>
-                        <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: bkt_data[:date_from], date_to: bkt_data[:date_to]), class: "block text-blue-600 hover:underline text-xs mt-1" %>
+                        <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: bkt_data[:date_from], date_to: bkt_data[:date_to]), class: "block text-accent hover:underline hover:text-accent-dark text-xs mt-1" %>
                       <% else %>
                         —
                       <% end %>
@@ -90,7 +91,7 @@
                   <% end %>
                   <td class="px-4 py-3 text-sm text-right font-medium">
                     <%= number_to_currency(cat[:total]) %>
-                    <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "block text-blue-600 hover:underline text-xs mt-1" %>
+                    <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "block text-accent hover:underline hover:text-accent-dark text-xs mt-1" %>
                   </td>
                 </tr>
               <% end %>
@@ -99,23 +100,24 @@
         </div>
         <div class="md:hidden divide-y divide-gray-200">
           <% @categories_summary.each do |cat| %>
-            <div class="p-4 border-b border-gray-200">
+            <div class="p-4 border-b border-border">
               <div class="flex justify-between items-center mb-3">
-                <span class="text-sm font-medium text-gray-900"><%= cat[:category_name] %></span>
+                <span class="text-sm font-medium text-foreground"><%= cat[:category_name] %></span>
                 <span class="text-sm font-medium"><%= number_to_currency(cat[:total]) %></span>
               </div>
               <% cat[:buckets].each do |bkt| %>
-                <div class="flex justify-between text-sm text-gray-600 mb-2">
+                <div class="flex justify-between text-sm text-muted-foreground mb-2">
                   <span><%= bkt[:label] %></span>
                   <span><%= number_to_currency(bkt[:amount]) %></span>
                 </div>
-                <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: bkt[:date_from], date_to: bkt[:date_to]), class: "text-blue-600 hover:underline text-xs" %>
+                <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: bkt[:date_from], date_to: bkt[:date_to]), class: "text-accent hover:underline hover:text-accent-dark text-xs" %>
               <% end %>
-              <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "inline-block mt-2 py-2 px-4 text-sm text-blue-600 hover:underline" %>
+              <%= link_to t("reports.view_expenses"), expenses_path(category_id: cat[:category_id], date_from: @date_from, date_to: @date_to), class: "inline-block mt-2 py-2 px-4 text-sm text-accent hover:underline hover:text-accent-dark" %>
             </div>
           <% end %>
         </div>
-      </section>
-    <% end %>
+
+      <% end %>
+    </section>
   <% end %>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -4,22 +4,22 @@
 
   <%= form_with url: session_url, class: "contents" do |form| %>
     <div class="my-5">
-      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: t("sessions.email_placeholder"), value: params[:email_address], class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: t("sessions.email_placeholder"), value: params[:email_address], class: "block shadow-sm rounded-md border border-input focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="my-5">
-      <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: t("sessions.password_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-gray-400 focus:outline-blue-600 px-3 py-2 mt-2 w-full" %>
+      <%= form.password_field :password, required: true, autocomplete: "current-password", placeholder: t("sessions.password_placeholder"), maxlength: 72, class: "block shadow-sm rounded-md border border-input focus:outline-primary px-3 py-2 mt-2 w-full" %>
     </div>
 
     <div class="col-span-6 sm:flex sm:items-center sm:gap-4">
       <div class="inline">
-        <%= form.submit t("sessions.submit"), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-blue-600 hover:bg-blue-500 text-white inline-block font-medium cursor-pointer" %>
+        <%= form.submit t("sessions.submit"), class: "w-full sm:w-auto text-center rounded-md px-3.5 py-2.5 bg-primary hover:bg-primary text-white inline-block font-medium cursor-pointer" %>
       </div>
 
-      <div class="mt-4 text-sm text-gray-500 sm:mt-0">
-        <%= link_to t("sessions.forgot_password"), new_password_path, class: "text-gray-700 underline hover:no-underline" %>
+      <div class="mt-4 text-sm text-muted-foreground sm:mt-0">
+        <%= link_to t("sessions.forgot_password"), new_password_path, class: "text-foreground underline hover:no-underline" %>
         <span class="mx-2">|</span>
-        <%= link_to t("sessions.sign_up_link"), new_registration_path, class: "text-gray-700 underline hover:no-underline" %>
+        <%= link_to t("sessions.sign_up_link"), new_registration_path, class: "text-foreground underline hover:no-underline" %>
       </div>
     </div>
   <% end %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -2,14 +2,14 @@
 <div class="container mx-auto px-4 py-6">
   <h1 class="text-2xl font-bold mb-4"><%= t("settings.title") %></h1>
 
-  <nav class="mb-6 border-b border-gray-200" aria-label="Settings sections">
+  <nav class="mb-6 border-b border-border" aria-label="Settings sections">
     <div class="flex gap-4">
       <%= link_to t("settings.sections.general"),
           edit_settings_path(section: "general"),
-          class: "pb-2 border-b-2 #{@section == "general" ? "border-blue-500 text-blue-700 font-semibold" : "border-transparent text-gray-600 hover:text-gray-900"}" %>
+          class: "pb-2 border-b-2 #{@section == "general" ? "border-blue-500 text-accent font-semibold" : "border-transparent text-muted-foreground hover:text-foreground"}" %>
       <%= link_to t("settings.sections.finance"),
           edit_settings_path(section: "finance"),
-          class: "pb-2 border-b-2 #{@section == "finance" ? "border-blue-500 text-blue-700 font-semibold" : "border-transparent text-gray-600 hover:text-gray-900"}" %>
+          class: "pb-2 border-b-2 #{@section == "finance" ? "border-blue-500 text-accent font-semibold" : "border-transparent text-muted-foreground hover:text-foreground"}" %>
     </div>
   </nav>
 
@@ -17,15 +17,15 @@
     <section class="space-y-4">
       <div>
         <h2 class="text-xl font-semibold"><%= t("settings.finance.title") %></h2>
-        <p class="text-gray-600"><%= t("settings.finance.description") %></p>
+        <p class="text-muted-foreground"><%= t("settings.finance.description") %></p>
       </div>
 
-      <div class="border rounded-lg p-4 bg-white">
+      <div class="border rounded-lg p-4 bg-card">
         <div class="flex items-center justify-between gap-4">
           <div>
             <h3 class="font-semibold"><%= t("settings.finance.categories_title") %></h3>
-            <p class="text-sm text-gray-600"><%= t("settings.finance.categories_description") %></p>
-            <p class="text-sm text-gray-500 mt-1"><%= t("settings.finance.category_count", count: @category_count || 0) %></p>
+            <p class="text-sm text-muted-foreground"><%= t("settings.finance.categories_description") %></p>
+            <p class="text-sm text-muted-foreground mt-1"><%= t("settings.finance.category_count", count: @category_count || 0) %></p>
           </div>
           <%= render Ui::ButtonComponent.new(
               href: settings_finance_categories_path,
@@ -35,12 +35,12 @@
         </div>
       </div>
 
-      <div class="border rounded-lg p-4 bg-white">
+      <div class="border rounded-lg p-4 bg-card">
         <div class="flex items-center justify-between gap-4">
           <div>
             <h3 class="font-semibold">Assets Accounts</h3>
-            <p class="text-sm text-gray-600">Manage Assets accounts as Debit Cards, Invesmetns, savings, other bank accounts</p>
-            <p class="text-sm text-gray-500 mt-1">Available Accounts -</p>
+            <p class="text-sm text-muted-foreground">Manage Assets accounts as Debit Cards, Invesmetns, savings, other bank accounts</p>
+            <p class="text-sm text-muted-foreground mt-1">Available Accounts -</p>
           </div>
           <%= render Ui::ButtonComponent.new(
               href: finance_financial_accounts_path,
@@ -50,12 +50,12 @@
         </div>
       </div>
       
-      <div class="border rounded-lg p-4 bg-white">
+      <div class="border rounded-lg p-4 bg-card">
         <div class="flex items-center justify-between gap-4">
           <div>
             <h3 class="font-semibold">Liability Accounts</h3>
-            <p class="text-sm text-gray-600">Manage Liability acccounts such as Credit cards, Personal loands and others</p>
-            <p class="text-sm text-gray-500 mt-1">Available Accounts -</p>
+            <p class="text-sm text-muted-foreground">Manage Liability acccounts such as Credit cards, Personal loands and others</p>
+            <p class="text-sm text-muted-foreground mt-1">Available Accounts -</p>
           </div>
           <%= render Ui::ButtonComponent.new(
               href: finance_financial_liabilities_path,
@@ -69,14 +69,14 @@
     <section class="space-y-4">
       <div>
         <h2 class="text-xl font-semibold"><%= t("settings.general.title") %></h2>
-        <p class="text-gray-600"><%= t("settings.general.description") %></p>
+        <p class="text-muted-foreground"><%= t("settings.general.description") %></p>
       </div>
 
       <%= form_with model: Current.user, url: settings_path, method: :patch, local: true do |f| %>
         <% if Current.user.errors.any? %>
-          <div class="mb-4 p-4 bg-red-50 border border-red-200 rounded">
-            <h2 class="font-bold text-red-800"><%= pluralize(Current.user.errors.count, "error") %> prohibited settings from being updated:</h2>
-            <ul class="list-disc list-inside text-red-700">
+          <div class="mb-4 p-4 bg-danger-soft border border-danger-soft rounded">
+            <h2 class="font-bold text-danger"><%= pluralize(Current.user.errors.count, "error") %> prohibited settings from being updated:</h2>
+            <ul class="list-disc list-inside text-danger">
               <% Current.user.errors.full_messages.each do |message| %>
                 <li><%= message %></li>
               <% end %>
@@ -85,18 +85,28 @@
         <% end %>
 
         <div class="mb-4">
-          <%= f.label :locale, t("settings.language"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+          <%= f.label :locale, t("settings.language"), class: "block text-sm font-medium text-foreground mb-1" %>
           <%= f.select :locale,
               options_for_select(
                 I18n.available_locales.map { |l| [t("locales.#{l}"), l.to_s] },
                 Current.user.locale
               ),
               {},
-              class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-500" %>
+              class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-primary" %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :theme_palette, t("settings.theme_palette"), class: "block text-sm font-medium text-foreground mb-1" %>
+          <%= f.select :theme_palette,
+              options_for_select(theme_palette_options, current_theme_palette),
+              {},
+              class: "w-full px-3 py-2 border rounded focus:outline-none focus:ring-2 focus:ring-primary",
+              data: { action: "change->theme#changePalette", theme_target: "paletteSelect", autosave: "true" } %>
+          <p class="mt-1 text-sm text-muted-foreground"><%= t("settings.theme_palette_description") %></p>
         </div>
 
         <div class="flex space-x-2">
-          <%= f.submit t("settings.update"), class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+          <%= f.submit t("settings.update"), class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
           <%= render Ui::ButtonComponent.new(href: root_path, label: t("settings.cancel"), variant: "ghost") %>
         </div>
       <% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,7 +1,7 @@
 <% if alert = flash[:alert] %>
-  <p class="py-2 px-3 bg-red-50 mb-3 text-red-700 font-medium rounded-lg" id="alert"><%= alert %></p>
+  <p class="py-2 px-3 bg-danger-soft mb-3 text-danger font-medium rounded-lg" id="alert"><%= alert %></p>
 <% end %>
 
 <% if notice = flash[:notice] %>
-  <p class="py-2 px-3 bg-green-50 mb-3 text-green-700 font-medium rounded-lg" id="notice"><%= notice %></p>
+  <p class="py-2 px-3 bg-green-50 mb-3 text-success font-medium rounded-lg" id="notice"><%= notice %></p>
 <% end %>

--- a/app/views/shopping_items/_form.html.erb
+++ b/app/views/shopping_items/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @shopping_item, local: true do |form| %>
   <% if @shopping_item.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@shopping_item.errors.count, "error") %> prohibited this shopping item from being saved:</h2>
       <ul class="list-disc list-inside">
         <% @shopping_item.errors.full_messages.each do |message| %>
@@ -11,48 +11,48 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full", required: true %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :category_id, "Category", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :category_id, @categories, :id, :name, { prompt: "Select a category (optional)" }, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :quantity, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :quantity, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :quantity, class: "border rounded px-3 py-2 w-full", placeholder: "e.g., 2, 1 pack, 500g" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :estimated_amount, "Estimated Amount", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :estimated_amount, "Estimated Amount", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.number_field :estimated_amount, step: 0.01, class: "border rounded px-3 py-2 w-full", placeholder: "0.00" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :item_type, "Type", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :item_type, "Type", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :item_type, [["One Time", "one_time"], ["Recurring", "recurring"]], {}, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4" id="recurring-fields" style="<%= @shopping_item.item_type == 'recurring' ? '' : 'display: none;' %>">
-    <%= form.label :frequency, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :frequency, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :frequency, class: "border rounded px-3 py-2 w-full", placeholder: "e.g., weekly, monthly" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :status, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :status, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :status, [["Pending", "pending"], ["Purchased", "purchased"]], {}, { class: "border rounded px-3 py-2 w-full" } %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to "Cancel", @shopping_item.persisted? ? @shopping_item : shopping_items_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to "Cancel", @shopping_item.persisted? ? @shopping_item : shopping_items_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/shopping_items/convert_to_expense.html.erb
+++ b/app/views/shopping_items/convert_to_expense.html.erb
@@ -3,21 +3,21 @@
 <p class="mb-4">Convert "<%= @shopping_item.name %>" to an expense.</p>
 
 <% if @shopping_item.estimated_amount.blank? || @shopping_item.estimated_amount <= 0 %>
-  <div class="bg-yellow-50 border border-yellow-200 text-yellow-700 px-4 py-3 rounded mb-4">
+  <div class="bg-yellow-50 border border-warning-soft text-yellow-700 px-4 py-3 rounded mb-4">
     <p><strong>Warning:</strong> This shopping item doesn't have an estimated amount. You'll need to add one before converting.</p>
-    <%= link_to "Edit Shopping Item", edit_shopping_item_path(@shopping_item), class: "text-blue-500 hover:underline" %>
+    <%= link_to "Edit Shopping Item", edit_shopping_item_path(@shopping_item), class: "text-accent hover:underline" %>
   </div>
 <% end %>
 
 <%= form_with url: convert_to_expense_shopping_item_path(@shopping_item), method: :post, local: true do |form| %>
   <div class="mb-4">
-    <%= form.label :budget_period_id, "Budget Period", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :budget_period_id, "Budget Period", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :budget_period_id, @budget_periods, :id, :name, { prompt: "Select a budget period" }, { class: "border rounded px-3 py-2 w-full", required: true } %>
   </div>
 
   <div class="mb-4">
     <%= form.submit "Convert", class: "px-4 py-2 bg-indigo-500 text-white rounded hover:bg-indigo-600" %>
-    <%= link_to "Cancel", @shopping_item, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= link_to "Cancel", @shopping_item, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/shopping_items/convert_to_planned_expense.html.erb
+++ b/app/views/shopping_items/convert_to_planned_expense.html.erb
@@ -3,21 +3,21 @@
 <p class="mb-4">Convert "<%= @shopping_item.name %>" to a planned expense.</p>
 
 <% if @shopping_item.estimated_amount.blank? || @shopping_item.estimated_amount <= 0 %>
-  <div class="bg-yellow-50 border border-yellow-200 text-yellow-700 px-4 py-3 rounded mb-4">
+  <div class="bg-yellow-50 border border-warning-soft text-yellow-700 px-4 py-3 rounded mb-4">
     <p><strong>Warning:</strong> This shopping item doesn't have an estimated amount. You'll need to add one before converting.</p>
-    <%= link_to "Edit Shopping Item", edit_shopping_item_path(@shopping_item), class: "text-blue-500 hover:underline" %>
+    <%= link_to "Edit Shopping Item", edit_shopping_item_path(@shopping_item), class: "text-accent hover:underline" %>
   </div>
 <% end %>
 
 <%= form_with url: convert_to_planned_expense_shopping_item_path(@shopping_item), method: :post, local: true do |form| %>
   <div class="mb-4">
-    <%= form.label :income_event_id, "Income Event", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :income_event_id, "Income Event", class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.collection_select :income_event_id, @income_events, :id, :description, { prompt: "Select an income event" }, { class: "border rounded px-3 py-2 w-full", required: true } %>
   </div>
 
   <div class="mb-4">
     <%= form.submit "Convert", class: "px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600" %>
-    <%= link_to "Cancel", @shopping_item, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= link_to "Cancel", @shopping_item, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>
 

--- a/app/views/shopping_items/index.html.erb
+++ b/app/views/shopping_items/index.html.erb
@@ -12,11 +12,11 @@
 
     <div class="flex flex-wrap gap-2">
       <%= link_to t("shopping_items.index.pending"), shopping_items_path(status: "pending"),
-          class: "px-3 py-1.5 rounded #{@status_filter == 'pending' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
-      <%= link_to t("shopping_items.index.purchased"), shopping_items_path(status: "purchased"),
-          class: "px-3 py-1.5 rounded #{@status_filter == 'purchased' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@status_filter == 'pending' ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
+        <%= link_to t("shopping_items.index.purchased"), shopping_items_path(status: "purchased"),
+          class: "px-3 py-1.5 rounded #{@status_filter == 'purchased' ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
       <%= link_to t("shopping_items.index.all"), shopping_items_path(status: "all"),
-          class: "px-3 py-1.5 rounded #{@status_filter == 'all' ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+          class: "px-3 py-1.5 rounded #{@status_filter == 'all' ? 'nav-link-active' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
     </div>
   </div>
 
@@ -24,34 +24,34 @@
     <div class="space-y-8">
       <% @grouped_shopping_items.each do |category, items| %>
         <section>
-          <h2 class="text-lg font-semibold text-gray-800 mb-3 pb-2 border-b border-gray-200">
+          <h2 class="text-lg font-semibold text-foreground mb-3 pb-2 border-b border-border">
             <%= category ? category.name : t("shopping_items.index.uncategorized") %>
           </h2>
           <div class="space-y-4">
             <% items.each do |shopping_item| %>
-              <div class="bg-white rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-gray-200 overflow-hidden">
+              <div class="bg-card rounded-xl shadow-md hover:shadow-xl transition-all duration-200 border border-border overflow-hidden">
                 <div class="p-6">
                   <div class="flex flex-wrap items-center gap-2 mb-3">
-                    <%= link_to shopping_item.name, shopping_item, class: "text-lg font-semibold text-gray-900 hover:text-blue-600 hover:underline" %>
-                    <span class="px-2 py-1 rounded text-xs <%= shopping_item.status == 'pending' ? 'bg-yellow-100 text-yellow-800' : 'bg-green-100 text-green-800' %>">
+                    <%= link_to shopping_item.name, shopping_item, class: "text-lg font-semibold text-foreground hover:text-accent-dark hover:underline" %>
+                    <span class="px-2 py-1 rounded text-xs <%= shopping_item.status == 'pending' ? 'bg-warning-soft text-warning' : 'bg-success-soft text-success' %>">
                       <%= t("activerecord.attributes.shopping_item.status_options.#{shopping_item.status}") %>
                     </span>
-                    <span class="px-2 py-1 rounded text-xs bg-gray-100 text-gray-800">
+                    <span class="px-2 py-1 rounded text-xs bg-muted text-foreground">
                       <%= t("activerecord.attributes.shopping_item.item_type.#{shopping_item.item_type}") %>
                     </span>
                   </div>
-                  <p class="text-sm text-gray-600 mb-4">
+                  <p class="text-sm text-muted-foreground mb-4">
                     <%= shopping_item.category&.name || "-" %> · <%= shopping_item.quantity.presence || "-" %> · <%= shopping_item.estimated_amount ? number_to_currency(shopping_item.estimated_amount) : "-" %>
                   </p>
                   <div class="flex flex-wrap gap-2 items-center justify-start">
-                    <%= link_to t("shared.view"), shopping_item, class: "inline-flex items-center justify-center px-4 py-2 bg-blue-500 text-white text-sm rounded-lg hover:bg-blue-600 transition-colors" %>
-                    <%= link_to t("shared.edit"), edit_shopping_item_path(shopping_item), class: "inline-flex items-center justify-center px-4 py-2 bg-gray-200 text-gray-700 text-sm rounded-lg hover:bg-gray-300 transition-colors" %>
+                    <%= link_to t("shared.view"), shopping_item, class: "btn btn-primary" %>
+                    <%= link_to t("shared.edit"), edit_shopping_item_path(shopping_item), class: "inline-flex items-center justify-center px-4 py-2 bg-muted text-foreground text-sm rounded-lg hover:bg-muted/80 transition-colors" %>
                     <% if shopping_item.status == "pending" %>
                       <%= link_to t("shopping_items.index.mark_purchased"), mark_as_purchased_shopping_item_path(shopping_item),
                           data: { turbo_method: :patch },
-                          class: "inline-flex items-center justify-center px-4 py-2 bg-green-500 text-white text-sm rounded-lg hover:bg-green-600 transition-colors" %>
+                          class: "inline-flex items-center justify-center px-4 py-2 bg-primary text-white text-sm rounded-lg hover:bg-primary/90 transition-colors" %>
                     <% end %>
-                    <%= button_to t("shared.delete"), shopping_item, method: :delete, data: { turbo_confirm: t("shared.confirm_destroy") }, class: "inline-flex items-center justify-center px-4 py-2 bg-red-500 text-white text-sm rounded-lg hover:bg-red-600 transition-colors" %>
+                    <%= button_to t("shared.delete"), shopping_item, method: :delete, data: { turbo_confirm: t("shared.confirm_destroy") }, class: "inline-flex items-center justify-center px-4 py-2 bg-danger-soft text-white text-sm rounded-lg hover:bg-danger/90 transition-colors" %>
                   </div>
                 </div>
               </div>
@@ -62,7 +62,7 @@
     </div>
   <% else %>
     <div class="text-center py-12">
-      <p class="text-gray-500"><%= t("shopping_items.index.empty") %></p>
+      <p class="text-muted-foreground"><%= t("shopping_items.index.empty") %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/shopping_items/link_to_planned_expense.html.erb
+++ b/app/views/shopping_items/link_to_planned_expense.html.erb
@@ -3,13 +3,13 @@
 <p class="mb-4">Link "<%= @shopping_item.name %>" to an existing planned expense.</p>
 
 <% if @planned_expenses.empty? %>
-  <div class="bg-yellow-50 border border-yellow-200 text-yellow-700 px-4 py-3 rounded mb-4">
+  <div class="bg-yellow-50 border border-warning-soft text-yellow-700 px-4 py-3 rounded mb-4">
     <p>No unlinked planned expenses found.</p>
   </div>
 <% else %>
   <%= form_with url: link_to_planned_expense_shopping_item_path(@shopping_item), method: :patch, local: true do |form| %>
     <div class="mb-4">
-      <%= form.label :planned_expense_id, "Planned Expense", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= form.label :planned_expense_id, "Planned Expense", class: "block text-sm font-medium text-foreground mb-1" %>
       <%= form.collection_select :planned_expense_id, @planned_expenses, :id, 
           lambda { |pe| "#{pe.description} - #{number_to_currency(pe.amount)} (#{pe.income_event.description})" }, 
           { prompt: "Select a planned expense" }, 
@@ -17,8 +17,8 @@
     </div>
 
     <div class="mb-4">
-      <%= form.submit "Link", class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-      <%= link_to "Cancel", @shopping_item, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+      <%= form.submit "Link", class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+      <%= link_to "Cancel", @shopping_item, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/shopping_items/show.html.erb
+++ b/app/views/shopping_items/show.html.erb
@@ -1,7 +1,7 @@
 <p style="color: green"><%= notice %></p>
 
 <div class="mb-4">
-  <%= link_to "← Back to Shopping List", shopping_items_path, class: "text-blue-500 hover:underline" %>
+  <%= link_to "← Back to Shopping List", shopping_items_path, class: "text-accent hover:underline" %>
 </div>
 
 <h1 class="text-2xl font-bold mb-4"><%= @shopping_item.name %></h1>
@@ -26,50 +26,50 @@
   <% end %>
 </div>
 
-<div class="bg-gray-50 p-4 rounded mb-4">
+<div class="bg-muted/35 p-4 rounded mb-4">
   <h2 class="text-xl font-semibold mb-2">Details</h2>
   <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
     <div>
-      <p class="text-sm text-gray-600">Status</p>
+      <p class="text-sm text-muted-foreground">Status</p>
       <p class="font-semibold">
-        <span class="px-2 py-1 rounded text-xs <%= @shopping_item.status == 'pending' ? 'bg-yellow-100 text-yellow-800' : 'bg-green-100 text-green-800' %>">
+        <span class="px-2 py-1 rounded text-xs <%= @shopping_item.status == 'pending' ? 'bg-warning-soft text-warning' : 'bg-success-soft text-success' %>">
           <%= t("activerecord.attributes.shopping_item.status_options.#{@shopping_item.status}") %>
         </span>
       </p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Type</p>
+      <p class="text-sm text-muted-foreground">Type</p>
       <p class="font-semibold">
-        <span class="px-2 py-1 rounded text-xs bg-gray-100 text-gray-800">
+        <span class="px-2 py-1 rounded text-xs bg-muted text-foreground">
           <%= t("activerecord.attributes.shopping_item.item_type.#{@shopping_item.item_type}") %>
         </span>
       </p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Category</p>
+      <p class="text-sm text-muted-foreground">Category</p>
       <p class="font-semibold"><%= @shopping_item.category&.name || "-" %></p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Quantity</p>
+      <p class="text-sm text-muted-foreground">Quantity</p>
       <p class="font-semibold"><%= @shopping_item.quantity || "-" %></p>
     </div>
     <div>
-      <p class="text-sm text-gray-600">Estimated Amount</p>
+      <p class="text-sm text-muted-foreground">Estimated Amount</p>
       <p class="font-semibold"><%= @shopping_item.estimated_amount ? number_to_currency(@shopping_item.estimated_amount) : "-" %></p>
     </div>
     <% if @shopping_item.item_type == "recurring" %>
       <div>
-        <p class="text-sm text-gray-600">Frequency</p>
+        <p class="text-sm text-muted-foreground">Frequency</p>
         <p class="font-semibold"><%= @shopping_item.frequency || "-" %></p>
       </div>
       <div>
-        <p class="text-sm text-gray-600">Last Purchased</p>
+        <p class="text-sm text-muted-foreground">Last Purchased</p>
         <p class="font-semibold"><%= @shopping_item.last_purchased_at ? @shopping_item.last_purchased_at.strftime("%B %d, %Y") : "-" %></p>
       </div>
     <% end %>
     <% if @shopping_item.notes.present? %>
       <div class="col-span-2">
-        <p class="text-sm text-gray-600">Notes</p>
+        <p class="text-sm text-muted-foreground">Notes</p>
         <p class="font-semibold"><%= @shopping_item.notes %></p>
       </div>
     <% end %>
@@ -77,28 +77,28 @@
 </div>
 
 <% if @shopping_item.planned_expense %>
-  <div class="bg-blue-50 p-4 rounded mb-4">
+  <div class="bg-muted/35 p-4 rounded mb-4">
     <h2 class="text-xl font-semibold mb-2">Linked Planned Expense</h2>
-    <p><%= link_to @shopping_item.planned_expense.description, income_event_planned_expense_path(@shopping_item.planned_expense.income_event, @shopping_item.planned_expense), class: "text-blue-500 hover:underline" %></p>
+    <p><%= link_to @shopping_item.planned_expense.description, income_event_planned_expense_path(@shopping_item.planned_expense.income_event, @shopping_item.planned_expense), class: "text-accent hover:underline" %></p>
   </div>
 <% end %>
 
 <% if @shopping_item.expense %>
-  <div class="bg-blue-50 p-4 rounded mb-4">
+  <div class="bg-muted/35 p-4 rounded mb-4">
     <h2 class="text-xl font-semibold mb-2">Linked Expense</h2>
-    <p><%= link_to @shopping_item.expense.description, @shopping_item.expense, class: "text-blue-500 hover:underline" %></p>
+    <p><%= link_to @shopping_item.expense.description, @shopping_item.expense, class: "text-accent hover:underline" %></p>
   </div>
 <% end %>
 
-<div class="bg-white border p-4 rounded mb-4">
+<div class="bg-card border p-4 rounded mb-4">
   <h2 class="text-xl font-semibold mb-2">Budget Integration</h2>
   <div class="flex flex-wrap gap-2 justify-center sm:justify-start">
     <%= link_to t("shopping_items.show.convert_to_planned_expense"), convert_to_planned_expense_shopping_item_path(@shopping_item),
-        class: "inline-flex items-center justify-center w-full sm:w-auto px-4 py-2 bg-purple-500 text-white rounded hover:bg-purple-600 transition-colors text-center" %>
+        class: "btn btn-secondary w-full sm:w-auto text-center" %>
     <%= link_to t("shopping_items.show.convert_to_expense"), convert_to_expense_shopping_item_path(@shopping_item),
         class: "inline-flex items-center justify-center w-full sm:w-auto px-4 py-2 bg-indigo-500 text-white rounded hover:bg-indigo-600 transition-colors text-center" %>
     <%= link_to t("shopping_items.show.link_to_planned_expense"), link_to_planned_expense_shopping_item_path(@shopping_item),
-        class: "inline-flex items-center justify-center w-full sm:w-auto px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors text-center" %>
+        class: "btn btn-primary w-full sm:w-auto text-center" %>
   </div>
 </div>
 

--- a/app/views/task/areas/_form.html.erb
+++ b/app/views/task/areas/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: task_area, url: task_area.persisted? ? task_area_path(task_area) : task_areas_path, method: task_area.persisted? ? :patch : :post, local: true do |form| %>
   <% if task_area.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= t("shared.errors_prohibited_save", count: task_area.errors.count, resource: t("task.areas.model_name").downcase) %></h2>
       <ul class="list-disc list-inside">
         <% task_area.errors.full_messages.each do |message| %>
@@ -11,12 +11,12 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, t("task.areas.form.name"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, t("task.areas.form.name"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to t("shared.cancel"), task_area.persisted? ? task_areas_path : task_areas_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+    <%= link_to t("shared.cancel"), task_area.persisted? ? task_areas_path : task_areas_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>

--- a/app/views/task/areas/edit.html.erb
+++ b/app/views/task/areas/edit.html.erb
@@ -3,5 +3,5 @@
 <%= render "form", task_area: @task_area %>
 
 <p class="mt-4">
-  <%= link_to t("shared.back"), task_areas_path, class: "text-blue-600 hover:underline" %>
+  <%= link_to t("shared.back"), task_areas_path, class: "text-accent hover:underline" %>
 </p>

--- a/app/views/task/areas/index.html.erb
+++ b/app/views/task/areas/index.html.erb
@@ -4,13 +4,13 @@
 <h1 class="text-2xl font-bold mb-4"><%= t("task.areas.index.title") %></h1>
 
 <div class="mb-4 flex justify-between items-center">
-  <%= link_to t("task.areas.new_area"), new_task_area_path, class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-  <%= link_to t("task.recurring_tasks.index.title"), task_root_path, class: "text-blue-600 hover:underline" %>
+  <%= link_to t("task.areas.new_area"), new_task_area_path, class: "px-4 py-2 bg-primary text-white rounded hover:bg-primary" %>
+  <%= link_to t("task.recurring_tasks.index.title"), task_root_path, class: "text-accent hover:underline" %>
 </div>
 
-<table class="min-w-full bg-white border">
+<table class="ui-table">
   <thead>
-    <tr class="bg-gray-100">
+    <tr class="bg-muted">
       <th class="px-4 py-2 text-left"><%= t("shared.name") %></th>
       <th class="px-4 py-2 text-left"><%= t("shared.actions") %></th>
     </tr>
@@ -20,8 +20,8 @@
       <tr class="border-t">
         <td class="px-4 py-2"><%= task_area.name %></td>
         <td class="px-4 py-2">
-          <%= link_to t("shared.edit"), edit_task_area_path(task_area), class: "text-blue-500 hover:underline" %>
-          <%= link_to t("shared.delete"), task_area_path(task_area), data: { turbo_method: :delete, turbo_confirm: t("shared.confirm_destroy") }, class: "text-red-500 hover:underline ml-2" %>
+          <%= link_to t("shared.edit"), edit_task_area_path(task_area), class: "text-accent hover:underline" %>
+          <%= link_to t("shared.delete"), task_area_path(task_area), data: { turbo_method: :delete, turbo_confirm: t("shared.confirm_destroy") }, class: "text-danger hover:underline ml-2" %>
         </td>
       </tr>
     <% end %>

--- a/app/views/task/areas/new.html.erb
+++ b/app/views/task/areas/new.html.erb
@@ -3,5 +3,5 @@
 <%= render "form", task_area: @task_area %>
 
 <p class="mt-4">
-  <%= link_to t("shared.back"), task_areas_path, class: "text-blue-600 hover:underline" %>
+  <%= link_to t("shared.back"), task_areas_path, class: "text-accent hover:underline" %>
 </p>

--- a/app/views/task/areas/show.html.erb
+++ b/app/views/task/areas/show.html.erb
@@ -3,5 +3,5 @@
   <strong><%= t("shared.name") %>:</strong> <%= @task_area.name %>
 </p>
 
-<%= link_to t("shared.edit"), edit_task_area_path(@task_area), class: "text-blue-600 hover:underline" %>
-<%= link_to t("shared.back"), task_areas_path, class: "text-blue-600 hover:underline ml-2" %>
+<%= link_to t("shared.edit"), edit_task_area_path(@task_area), class: "text-accent hover:underline" %>
+<%= link_to t("shared.back"), task_areas_path, class: "text-accent hover:underline ml-2" %>

--- a/app/views/task/recurring_tasks/_form.html.erb
+++ b/app/views/task/recurring_tasks/_form.html.erb
@@ -5,7 +5,7 @@
 %>
 <%= form_with model: recurring_task, url: recurring_task.persisted? ? task_recurring_task_path(recurring_task, index_path_options) : task_recurring_tasks_path(index_path_options), method: recurring_task.persisted? ? :patch : :post, local: true do |form| %>
   <% if recurring_task.errors.any? %>
-    <div class="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded mb-4">
+    <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= t("shared.errors_prohibited_save", count: recurring_task.errors.count, resource: t("task.recurring_tasks.model_name").downcase) %></h2>
       <ul class="list-disc list-inside">
         <% recurring_task.errors.full_messages.each do |message| %>
@@ -16,32 +16,32 @@
   <% end %>
 
   <div class="mb-4">
-    <%= form.label :name, t("task.recurring_tasks.form.name"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :name, t("task.recurring_tasks.form.name"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_field :name, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :task_area_id, t("task.recurring_tasks.form.area"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :task_area_id, t("task.recurring_tasks.form.area"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :task_area_id, options_from_collection_for_select(@task_areas, :id, :name, recurring_task.task_area_id), { include_blank: t("task.recurring_tasks.form.no_area") }, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :recurrence, t("task.recurring_tasks.form.recurrence"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :recurrence, t("task.recurring_tasks.form.recurrence"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.select :recurrence, RecurringTask::RECURRENCE_VALUES.map { |v| [ t("task.recurring_tasks.recurrence.#{v}"), v ] }, {}, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :next_due_date, t("task.recurring_tasks.form.next_due_date"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :next_due_date, t("task.recurring_tasks.form.next_due_date"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.date_field :next_due_date, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.label :notes, t("task.recurring_tasks.form.notes"), class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= form.label :notes, t("task.recurring_tasks.form.notes"), class: "block text-sm font-medium text-foreground mb-1" %>
     <%= form.text_area :notes, rows: 3, class: "border rounded px-3 py-2 w-full" %>
   </div>
 
   <div class="mb-4">
-    <%= form.submit class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
-    <%= link_to t("shared.cancel"), cancel_path, class: "px-4 py-2 bg-gray-300 text-gray-700 rounded hover:bg-gray-400 ml-2" %>
+    <%= form.submit class: "btn btn-primary" %>
+    <%= link_to t("shared.cancel"), cancel_path, class: "px-4 py-2 bg-muted text-foreground rounded hover:bg-muted/80 ml-2" %>
   </div>
 <% end %>

--- a/app/views/task/recurring_tasks/_task_card.html.erb
+++ b/app/views/task/recurring_tasks/_task_card.html.erb
@@ -3,29 +3,29 @@
   index_path_options = task_area_id_filter.present? ? { task_area_id: task_area_id_filter } : {}
   task_path_options = task_area_id_filter.present? ? { task_area_id: task_area_id_filter } : {}
 %>
-<div class="bg-white rounded-xl shadow-md hover:shadow-lg transition-all duration-200 border border-gray-200 overflow-hidden <%= 'border-l-4 border-l-red-500 bg-red-50/50' if task.overdue? %>">
+<div class="bg-card rounded-xl shadow-md hover:shadow-lg transition-all duration-200 border border-border overflow-hidden <%= 'border-l-4 border-l-red-500 bg-danger-soft/50' if task.overdue? %>">
   <div class="p-4 sm:p-6">
     <div class="flex flex-wrap items-start gap-2 mb-3">
-      <%= link_to task.name, task_recurring_task_path(task, task_path_options), data: { turbo_frame: "task_detail_panel" }, class: "text-lg font-semibold text-gray-900 hover:text-blue-600 hover:underline" %>
+      <%= link_to task.name, task_recurring_task_path(task, task_path_options), data: { turbo_frame: "task_detail_panel" }, class: "text-lg font-semibold text-foreground hover:text-accent-dark hover:underline" %>
       <% if task.overdue? %>
-        <span class="px-2 py-1 rounded text-xs font-medium bg-red-100 text-red-800"><%= t("task.recurring_tasks.overdue") %></span>
+        <span class="px-2 py-1 rounded text-xs font-medium bg-danger-soft text-danger"><%= t("task.recurring_tasks.overdue") %></span>
       <% end %>
       <% if task.task_area.present? %>
-        <span class="px-2 py-1 rounded text-xs bg-gray-100 text-gray-800"><%= task.task_area.name %></span>
+        <span class="px-2 py-1 rounded text-xs bg-muted text-foreground"><%= task.task_area.name %></span>
       <% end %>
     </div>
-    <p class="text-sm text-gray-600 mb-3">
+    <p class="text-sm text-muted-foreground mb-3">
       <%= t("task.recurring_tasks.index.next_due") %>: <%= task.next_due_date ? l(task.next_due_date, format: :short) : "—" %>
       <span class="mx-2">·</span>
       <%= t("task.recurring_tasks.recurrence.#{task.recurrence}") %>
     </p>
     <% if task.notes.present? %>
-      <p class="text-sm text-gray-600 mb-4" title="<%= task.notes %>"><%= truncate(task.notes, length: 80) %></p>
+      <p class="text-sm text-muted-foreground mb-4" title="<%= task.notes %>"><%= truncate(task.notes, length: 80) %></p>
     <% end %>
     <div class="flex flex-wrap gap-2 items-center">
-      <%= button_to t("task.recurring_tasks.mark_done"), mark_done_task_recurring_task_path(task, index_path_options), method: :patch, class: "inline-flex items-center justify-center px-4 py-2 bg-green-500 text-white text-sm rounded-lg hover:bg-green-600 transition-colors" %>
-      <%= link_to t("shared.edit"), edit_task_recurring_task_path(task, index_path_options), class: "inline-flex items-center justify-center px-4 py-2 bg-gray-200 text-gray-700 text-sm rounded-lg hover:bg-gray-300 transition-colors" %>
-      <%= link_to t("shared.delete"), task_recurring_task_path(task, index_path_options), data: { turbo_method: :delete, turbo_confirm: t("shared.confirm_destroy") }, class: "inline-flex items-center justify-center px-4 py-2 bg-red-500 text-white text-sm rounded-lg hover:bg-red-600 transition-colors" %>
+      <%= button_to t("task.recurring_tasks.mark_done"), mark_done_task_recurring_task_path(task, index_path_options), method: :patch, class: "inline-flex items-center justify-center px-4 py-2 bg-primary text-white text-sm rounded-lg hover:bg-primary/90 transition-colors" %>
+      <%= link_to t("shared.edit"), edit_task_recurring_task_path(task, index_path_options), class: "inline-flex items-center justify-center px-4 py-2 bg-muted text-foreground text-sm rounded-lg hover:bg-muted/80 transition-colors" %>
+      <%= link_to t("shared.delete"), task_recurring_task_path(task, index_path_options), data: { turbo_method: :delete, turbo_confirm: t("shared.confirm_destroy") }, class: "inline-flex items-center justify-center px-4 py-2 bg-danger-soft text-white text-sm rounded-lg hover:bg-danger/90 transition-colors" %>
     </div>
   </div>
 </div>

--- a/app/views/task/recurring_tasks/edit.html.erb
+++ b/app/views/task/recurring_tasks/edit.html.erb
@@ -4,6 +4,6 @@
   <%= render "form", recurring_task: @recurring_task, task_areas: @task_areas, task_area_id_filter: params[:task_area_id] %>
 
   <p class="mt-4">
-    <%= link_to t("shared.back"), task_root_path(task_area_id: params[:task_area_id]), class: "text-blue-600 hover:underline" %>
+    <%= link_to t("shared.back"), task_root_path(task_area_id: params[:task_area_id]), class: "text-accent hover:underline" %>
   </p>
 </div>

--- a/app/views/task/recurring_tasks/index.html.erb
+++ b/app/views/task/recurring_tasks/index.html.erb
@@ -4,42 +4,42 @@
 <div class="container mx-auto px-4">
   <h1 class="text-2xl font-bold mb-4"><%= t("nav.tasks") %></h1>
 
-  <section class="mb-8 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+  <section class="mb-8 rounded-lg border border-border bg-card p-4 shadow-sm">
     <div class="mb-3 flex items-center justify-between gap-3">
       <div>
-        <h2 class="text-lg font-semibold text-slate-900">Standalone tasks</h2>
-        <p class="text-sm text-slate-500">These are the tasks created without a project.</p>
+        <h2 class="text-lg font-semibold text-foreground">Standalone tasks</h2>
+        <p class="text-sm text-muted-foreground">These are the tasks created without a project.</p>
       </div>
-      <%= link_to "New task", task_root_path, class: "inline-flex items-center justify-center rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600 transition-colors" %>
+      <%= link_to "New task", task_root_path, class: "inline-flex items-center justify-center rounded-lg bg-primary px-4 py-2 text-white hover:bg-primary transition-colors" %>
     </div>
 
     <% if @standalone_tasks.any? %>
       <div class="space-y-3">
         <% @standalone_tasks.each do |task| %>
-          <div class="rounded-lg border border-slate-200 p-4">
-            <h3 class="font-medium text-slate-900"><%= task.title %></h3>
+          <div class="rounded-lg border border-border p-4">
+            <h3 class="font-medium text-foreground"><%= task.title %></h3>
             <% if task.description.present? %>
-              <p class="mt-1 text-sm text-slate-600"><%= task.description %></p>
+              <p class="mt-1 text-sm text-muted-foreground"><%= task.description %></p>
             <% end %>
-            <p class="mt-2 text-xs text-slate-500">Priority: <%= task.priority_label %> · Status: <%= task.status_label %></p>
+            <p class="mt-2 text-xs text-muted-foreground">Priority: <%= task.priority_label %> · Status: <%= task.status_label %></p>
           </div>
         <% end %>
       </div>
     <% else %>
-      <div class="rounded-lg border border-dashed border-slate-300 p-6 text-sm text-slate-500">No standalone tasks yet.</div>
+      <div class="rounded-lg border border-dashed border-input p-6 text-sm text-muted-foreground">No standalone tasks yet.</div>
     <% end %>
   </section>
 
   <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:justify-between sm:items-center">
     <div class="flex flex-wrap gap-2 items-center">
-      <%= link_to t("task.recurring_tasks.index.all_areas"), task_root_path, class: "px-3 py-1.5 rounded #{params[:task_area_id].blank? ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+      <%= link_to t("task.recurring_tasks.index.all_areas"), task_root_path, class: "px-3 py-1.5 rounded #{params[:task_area_id].blank? ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
       <% @task_areas.each do |area| %>
-        <%= link_to area.name, task_root_path(task_area_id: area.id), class: "px-3 py-1.5 rounded #{params[:task_area_id].to_s == area.id.to_s ? 'bg-blue-500 text-white' : 'bg-gray-200 text-gray-700 hover:bg-gray-300'}" %>
+        <%= link_to area.name, task_root_path(task_area_id: area.id), class: "px-3 py-1.5 rounded #{params[:task_area_id].to_s == area.id.to_s ? 'bg-primary text-white' : 'bg-muted text-foreground hover:bg-muted/80'}" %>
       <% end %>
     </div>
     <div class="flex flex-wrap gap-2 items-center">
-      <%= link_to t("task.recurring_tasks.new_task"), new_task_recurring_task_path(task_area_id: params[:task_area_id]), class: "inline-flex items-center justify-center px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors" %>
-      <%= link_to t("task.areas.index.title"), task_areas_path, class: "text-blue-600 hover:underline py-2" %>
+      <%= link_to t("task.recurring_tasks.new_task"), new_task_recurring_task_path(task_area_id: params[:task_area_id]), class: "inline-flex items-center justify-center px-4 py-2 bg-primary text-white rounded-lg hover:bg-primary transition-colors" %>
+      <%= link_to t("task.areas.index.title"), task_areas_path, class: "text-accent hover:underline py-2" %>
     </div>
   </div>
 
@@ -51,7 +51,7 @@
     </div>
   <% else %>
     <div class="text-center py-12">
-      <p class="text-gray-500"><%= t("task.recurring_tasks.index.empty") %></p>
+      <p class="text-muted-foreground"><%= t("task.recurring_tasks.index.empty") %></p>
     </div>
   <% end %>
 

--- a/app/views/task/recurring_tasks/new.html.erb
+++ b/app/views/task/recurring_tasks/new.html.erb
@@ -4,6 +4,6 @@
   <%= render "form", recurring_task: @recurring_task, task_areas: @task_areas, task_area_id_filter: params[:task_area_id] %>
 
   <p class="mt-4">
-    <%= link_to t("shared.back"), task_root_path(task_area_id: params[:task_area_id]), class: "text-blue-600 hover:underline" %>
+    <%= link_to t("shared.back"), task_root_path(task_area_id: params[:task_area_id]), class: "text-accent hover:underline" %>
   </p>
 </div>

--- a/app/views/task/recurring_tasks/show.html.erb
+++ b/app/views/task/recurring_tasks/show.html.erb
@@ -3,38 +3,38 @@
   tasks_index_path = task_root_path(index_path_options)
 %>
 <%= turbo_frame_tag "task_detail_panel" do %>
-  <div class="fixed inset-0 sm:inset-y-0 sm:right-0 sm:left-auto w-full sm:max-w-md bg-white shadow-xl z-50 overflow-y-auto overflow-x-hidden border-l border-gray-200 animate-slide-in-right">
+  <div class="fixed inset-0 sm:inset-y-0 sm:right-0 sm:left-auto w-full sm:max-w-md bg-card shadow-xl z-50 overflow-y-auto overflow-x-hidden border-l border-border animate-slide-in-right">
     <div class="p-6 min-w-0">
       <div class="flex justify-between items-start gap-2 mb-4">
-        <h2 class="text-xl font-bold text-gray-900 break-words flex-1 min-w-0"><%= @recurring_task.name %></h2>
-        <%= link_to t("task.recurring_tasks.show.close_panel"), tasks_index_path, data: { turbo_frame: "task_detail_panel" }, class: "flex-shrink-0 text-gray-500 hover:text-gray-700 text-sm p-2 rounded hover:bg-gray-100" %>
+        <h2 class="text-xl font-bold text-foreground break-words flex-1 min-w-0"><%= @recurring_task.name %></h2>
+        <%= link_to t("task.recurring_tasks.show.close_panel"), tasks_index_path, data: { turbo_frame: "task_detail_panel" }, class: "flex-shrink-0 text-muted-foreground hover:text-foreground text-sm p-2 rounded hover:bg-muted" %>
       </div>
 
       <dl class="space-y-3 text-sm">
         <div>
-          <dt class="font-medium text-gray-500"><%= t("task.recurring_tasks.index.area") %></dt>
-          <dd class="text-gray-900"><%= @recurring_task.task_area&.name || "—" %></dd>
+          <dt class="font-medium text-muted-foreground"><%= t("task.recurring_tasks.index.area") %></dt>
+          <dd class="text-foreground"><%= @recurring_task.task_area&.name || "—" %></dd>
         </div>
         <div>
-          <dt class="font-medium text-gray-500"><%= t("task.recurring_tasks.index.next_due") %></dt>
-          <dd class="text-gray-900"><%= @recurring_task.next_due_date ? l(@recurring_task.next_due_date, format: :short) : "—" %></dd>
+          <dt class="font-medium text-muted-foreground"><%= t("task.recurring_tasks.index.next_due") %></dt>
+          <dd class="text-foreground"><%= @recurring_task.next_due_date ? l(@recurring_task.next_due_date, format: :short) : "—" %></dd>
         </div>
         <div>
-          <dt class="font-medium text-gray-500"><%= t("task.recurring_tasks.index.recurrence") %></dt>
-          <dd class="text-gray-900"><%= t("task.recurring_tasks.recurrence.#{@recurring_task.recurrence}") %></dd>
+          <dt class="font-medium text-muted-foreground"><%= t("task.recurring_tasks.index.recurrence") %></dt>
+          <dd class="text-foreground"><%= t("task.recurring_tasks.recurrence.#{@recurring_task.recurrence}") %></dd>
         </div>
         <% if @recurring_task.notes.present? %>
           <div class="min-w-0">
-            <dt class="font-medium text-gray-500"><%= t("task.recurring_tasks.form.notes") %></dt>
-            <dd class="text-gray-900 whitespace-pre-wrap break-words"><%= @recurring_task.notes %></dd>
+            <dt class="font-medium text-muted-foreground"><%= t("task.recurring_tasks.form.notes") %></dt>
+            <dd class="text-foreground whitespace-pre-wrap break-words"><%= @recurring_task.notes %></dd>
           </div>
         <% end %>
       </dl>
 
-      <div class="mt-6 pt-4 border-t border-gray-200 flex flex-wrap gap-2">
-        <%= button_to t("task.recurring_tasks.mark_done"), mark_done_task_recurring_task_path(@recurring_task, index_path_options), method: :patch, form: { data: { turbo_frame: "_top" } }, class: "inline-flex items-center justify-center px-4 py-2 bg-green-500 text-white text-sm rounded-lg hover:bg-green-600" %>
-        <%= link_to t("shared.edit"), edit_task_recurring_task_path(@recurring_task, index_path_options), data: { turbo_frame: "_top" }, class: "inline-flex items-center justify-center px-4 py-2 bg-gray-200 text-gray-800 text-sm rounded-lg hover:bg-gray-300" %>
-        <%= link_to t("task.recurring_tasks.show.close_panel"), tasks_index_path, data: { turbo_frame: "task_detail_panel" }, class: "inline-flex items-center justify-center px-4 py-2 text-gray-600 hover:text-gray-800 text-sm" %>
+      <div class="mt-6 pt-4 border-t border-border flex flex-wrap gap-2">
+        <%= button_to t("task.recurring_tasks.mark_done"), mark_done_task_recurring_task_path(@recurring_task, index_path_options), method: :patch, form: { data: { turbo_frame: "_top" } }, class: "inline-flex items-center justify-center px-4 py-2 bg-primary text-white text-sm rounded-lg hover:bg-primary/90" %>
+        <%= link_to t("shared.edit"), edit_task_recurring_task_path(@recurring_task, index_path_options), data: { turbo_frame: "_top" }, class: "inline-flex items-center justify-center px-4 py-2 bg-muted text-foreground text-sm rounded-lg hover:bg-muted/80" %>
+        <%= link_to t("task.recurring_tasks.show.close_panel"), tasks_index_path, data: { turbo_frame: "task_detail_panel" }, class: "inline-flex items-center justify-center px-4 py-2 text-muted-foreground hover:text-foreground text-sm" %>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,6 +212,8 @@ en:
         other: "%{count} categories"
       manage_categories: "Manage categories"
     language: "Language"
+    theme_palette: "Color palette"
+    theme_palette_description: "Choose a curated iOS-inspired palette for this account. Changes apply across light and dark mode."
     update: "Save changes"
     updated: "Settings updated."
     cancel: "Cancel"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -212,6 +212,8 @@ es:
         other: "%{count} categorías"
       manage_categories: "Gestionar categorías"
     language: "Idioma"
+    theme_palette: "Paleta de color"
+    theme_palette_description: "Elige una paleta inspirada en iOS para esta cuenta. Los cambios se aplican en modo claro y oscuro."
     update: "Guardar cambios"
     updated: "Ajustes actualizados."
     cancel: "Cancelar"

--- a/db/migrate/20260514090000_add_theme_palette_to_users.rb
+++ b/db/migrate/20260514090000_add_theme_palette_to_users.rb
@@ -1,0 +1,5 @@
+class AddThemePaletteToUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :users, :theme_palette, :string, null: false, default: "ios-balanced"
+  end
+end

--- a/db/migrate/20260514094000_rename_legacy_theme_palettes.rb
+++ b/db/migrate/20260514094000_rename_legacy_theme_palettes.rb
@@ -1,0 +1,32 @@
+class RenameLegacyThemePalettes < ActiveRecord::Migration[8.1]
+  LEGACY_TO_NEW = {
+    "ios-balanced" => "executive-calm",
+    "ios-ocean" => "ocean-depth",
+    "ios-forest" => "forest-mint",
+    "ios-sunset" => "sunset-ember"
+  }.freeze
+
+  def up
+    LEGACY_TO_NEW.each do |legacy_value, new_value|
+      execute <<~SQL.squish
+        UPDATE users
+        SET theme_palette = '#{new_value}'
+        WHERE theme_palette = '#{legacy_value}'
+      SQL
+    end
+
+    change_column_default :users, :theme_palette, from: "ios-balanced", to: "executive-calm"
+  end
+
+  def down
+    LEGACY_TO_NEW.each do |legacy_value, new_value|
+      execute <<~SQL.squish
+        UPDATE users
+        SET theme_palette = '#{legacy_value}'
+        WHERE theme_palette = '#{new_value}'
+      SQL
+    end
+
+    change_column_default :users, :theme_palette, from: "executive-calm", to: "ios-balanced"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_08_014200) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_14_094000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -484,6 +484,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_08_014200) do
     t.string "locale", default: "en"
     t.string "name", null: false
     t.string "password_digest", null: false
+    t.string "theme_palette", default: "executive-calm", null: false
     t.datetime "updated_at", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end

--- a/scripts/wcag_contrast_check.py
+++ b/scripts/wcag_contrast_check.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+import re
+import math
+
+CSS_FILE = 'app/assets/tailwind/shadcn.css'
+
+def parse_tokens(path):
+    tokens = {}
+    with open(path, 'r') as f:
+        text = f.read()
+    # Prefer tokens declared in the :root block (light theme)
+    root_match = re.search(r":root\s*\{([\s\S]*?)\}\s*", text, re.I)
+    scope_text = root_match.group(1) if root_match else text
+    for m in re.finditer(r"--([a-z0-9-]+)\s*:\s*([^;]+);", scope_text, re.I):
+        name = m.group(1)
+        val = m.group(2).strip()
+        # only set once (first declaration in root wins)
+        if name not in tokens:
+            tokens[name] = val
+    return tokens
+
+def parse_hsl_value(val):
+    # Accept formats like: 40 18% 88%  OR 223 72% 46% OR 0 0% 100%
+    parts = val.split()
+    if len(parts) >= 3 and '%' in parts[1] and '%' in parts[2]:
+        h = float(parts[0])
+        s = float(parts[1].rstrip('%'))/100.0
+        l = float(parts[2].rstrip('%'))/100.0
+        return (h, s, l)
+    return None
+
+import colorsys
+
+def hsl_to_rgb(h,s,l):
+    # colorsys.hls_to_rgb expects H, L, S in 0..1
+    h_f = (h % 360) / 360.0
+    r,g,b = colorsys.hls_to_rgb(h_f, l, s)
+    return (r,g,b)
+
+def srgb_to_linear(c):
+    if c <= 0.04045:
+        return c/12.92
+    return ((c+0.055)/1.055) ** 2.4
+
+def relative_luminance(rgb):
+    r,g,b = rgb
+    R = srgb_to_linear(r)
+    G = srgb_to_linear(g)
+    B = srgb_to_linear(b)
+    return 0.2126*R + 0.7152*G + 0.0722*B
+
+def contrast_ratio(l1,l2):
+    L1 = max(l1,l2)
+    L2 = min(l1,l2)
+    return (L1+0.05)/(L2+0.05)
+
+pairs = [
+    ('background','foreground'),
+    ('card','card-foreground'),
+    ('sidebar-background','sidebar-foreground'),
+    ('sidebar-primary','sidebar-primary-foreground'),
+    ('primary','primary-foreground'),
+    ('accent','accent-foreground'),
+    ('border','foreground'),
+    ('input','foreground')
+]
+
+def main():
+    tokens = parse_tokens(CSS_FILE)
+    results = []
+    for a,b in pairs:
+        va = tokens.get(a)
+        vb = tokens.get(b)
+        if not va or not vb:
+            results.append((a,b,None,'missing token'))
+            continue
+        a_hsl = parse_hsl_value(va)
+        b_hsl = parse_hsl_value(vb)
+        if a_hsl and b_hsl:
+            ra = hsl_to_rgb(*a_hsl)
+            rb = hsl_to_rgb(*b_hsl)
+            la = relative_luminance(ra)
+            lb = relative_luminance(rb)
+            ratio = contrast_ratio(la,lb)
+            results.append((a,b,round(ratio,2), 'pass' if ratio>=4.5 else 'fail'))
+        else:
+            # fallback: try parse hex or simple numbers
+            results.append((a,b,None,'unsupported format'))
+
+    print('\nWCAG Contrast Check Report')
+    print('Checked pairs and results (target >= 4.5 for normal text):\n')
+    for r in results:
+        a,b,ratio,status = r
+        print(f"- {a} vs {b}: {ratio if ratio is not None else '-'} -> {status}")
+
+    # Print tokens used for debugging
+    print('\nTokens read:')
+    keys = sorted(tokens.keys())
+    for k in keys:
+        print(f"{k}: {tokens[k]}")
+
+if __name__ == '__main__':
+    main()

--- a/test/integration/dashboard_quick_add_test.rb
+++ b/test/integration/dashboard_quick_add_test.rb
@@ -10,8 +10,8 @@ class DashboardIntegrationTest < ActionDispatch::IntegrationTest
   test "dashboard renders quick-add menu component" do
     get root_path
     assert_response :success
-    assert_select "div.fixed.bottom-6.right-6.z-40" # FAB on mobile
-    assert_select "div.hidden.md\\:flex" # Toolbar on desktop
+    assert_select "div.fixed.right-4.z-40.md\\:hidden[data-controller='quick-add-menu']" # FAB on mobile
+    assert_select "div.fixed.right-5.top-5.z-40.hidden.md\\:flex[data-controller='quick-add-menu']" # Toolbar on desktop
   end
 
   test "quick add links are present on dashboard" do

--- a/test/integration/quick_add_view_render_test.rb
+++ b/test/integration/quick_add_view_render_test.rb
@@ -24,7 +24,9 @@ class QuickAddViewRenderTest < ActionDispatch::IntegrationTest
     get root_path
     if response.status == 200
       # Check for FAB on mobile
-      assert_select "div.fixed.bottom-6.right-6.z-40"
+      assert_select "div.fixed.right-4.z-40.md\\:hidden[data-controller='quick-add-menu']"
+      # Check for desktop quick actions container
+      assert_select "div.fixed.right-5.top-5.z-40.hidden.md\\:flex[data-controller='quick-add-menu']"
       # Check for link to quick-add
       assert_select "a[href*='quick-add']"
     end


### PR DESCRIPTION
## Summary
This PR delivers a full UX/UI polish pass focused on visual hierarchy, theme governance, and consistency across the app.  
It introduces a configurable theme palette system (including a shadcn default option), improves shell/sidebar/quick-action ergonomics, and standardizes styling across core views and components.

## What Changed
- Added user-level theme palette support with persistence.
- Added Settings controls to switch palette (with immediate UI application).
- Introduced palette normalization/migration for legacy values.
- Added `Shadcn Default` as a selectable theme option.
- Rebalanced theme tokens for light/dark modes using semantic color roles.
- Updated app shell styling (background, content surface, header behavior).
- Refined sidebar UX:
  - body aligned with content surface
  - header/footer use subtle contrast accents
- Improved quick actions and quick-add modal styling/positioning.
- Standardized button/switch/sidebar component styling.
- Applied consistency styling pass across major pages (dashboard, income events, financial, projects, reports, shopping, tasks, etc.).
- Added i18n labels for theme palette settings.
- Added a WCAG contrast helper script for visual QA support.

## Data / Backend Impact
- Added `users.theme_palette` column and migrations to map legacy palette values.
- No API contract or business-logic behavior changes beyond theme preference persistence.

## QA / Verification
- Tailwind assets rebuilt after styling/token updates.
- Manual visual checks performed for:
  - palette switching + persistence
  - light/dark behavior
  - sidebar/header/footer contrast
  - quick actions and modal presentation
  - cross-page consistency

## Notes
This PR is intentionally structured as many small, one-file commits for easier review and rollback granularity.