### PR TITLE
Implement financial account filtering in expenses and entries

### DIFF
--- a/app/controllers/concerns/financial/account_reference_filtering.rb
+++ b/app/controllers/concerns/financial/account_reference_filtering.rb
@@ -1,0 +1,44 @@
+module Financial::AccountReferenceFiltering
+  extend ActiveSupport::Concern
+
+  private
+
+  def load_account_filter_options
+    assets = Financial::Asset.for_account(Current.account).active.order(:name)
+    liabilities = Financial::Liability.for_account(Current.account).active.order(:name)
+
+    @account_filter_options = assets.map { |asset| [ "Asset · #{asset.name}", "asset:#{asset.id}" ] } +
+      liabilities.map { |liability| [ "Liability · #{liability.name}", "liability:#{liability.id}" ] }
+  end
+
+  def selected_account_ref
+    @selected_account_ref ||= parsed_account_ref ? params[:account_ref].to_s : nil
+  end
+
+  def apply_account_ref_filter(scope)
+    parsed = parsed_account_ref
+    return scope if parsed.blank?
+
+    type = parsed[:type]
+    id = parsed[:id]
+
+    case type
+    when "asset"
+      scope.where("financial_account_id = :id OR counterparty_financial_account_id = :id", id: id)
+    when "liability"
+      scope.where("financial_liability_id = :id OR counterparty_financial_liability_id = :id", id: id)
+    else
+      scope
+    end
+  end
+
+  def parsed_account_ref
+    @parsed_account_ref ||= begin
+      raw = params[:account_ref].to_s
+      match = raw.match(/\A(asset|liability):(\d+)\z/)
+      if match
+        { type: match[1], id: match[2].to_i }
+      end
+    end
+  end
+end

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -10,6 +10,7 @@ class ExpensesController < ApplicationController
 
   def index
     @expenses = Expense.for_account(Current.account).all
+    @expenses = apply_account_ref_filter(@expenses)
     @expenses = @expenses.where("date >= ?", params[:date_from]) if params[:date_from].present?
     @expenses = @expenses.where("date <= ?", params[:date_to])   if params[:date_to].present?
     @expenses = @expenses.where(category_id: params[:category_id]) if params[:category_id].present?

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -5,6 +5,7 @@ class ExpensesController < ApplicationController
   before_action :set_income_event_context, only: [ :quick_new, :quick_create ]
   before_action :set_expense, only: %i[ show edit update destroy ]
   before_action :load_finance_account_collections, only: [ :new, :create, :edit, :update, :quick_new, :quick_create ]
+  before_action :load_account_filter_options, only: [ :index ]
 
 
   def index

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -1,4 +1,6 @@
 class ExpensesController < ApplicationController
+  include Financial::AccountReferenceFiltering
+
   before_action :set_budget_period, only: [ :new, :create ]
   before_action :set_income_event_context, only: [ :quick_new, :quick_create ]
   before_action :set_expense, only: %i[ show edit update destroy ]

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -16,6 +16,7 @@ class ExpensesController < ApplicationController
     @expenses = @expenses.where(category_id: params[:category_id]) if params[:category_id].present?
     @expenses = @expenses.where("description ILIKE ?", "%#{params[:q]}%") if params[:q].present?
     @selected_account_ref = selected_account_ref
+    @categories = Category.for_account(Current.account).order(:name)
   end
 
   # GET /expenses or /expenses.json

--- a/app/controllers/expenses_controller.rb
+++ b/app/controllers/expenses_controller.rb
@@ -15,6 +15,7 @@ class ExpensesController < ApplicationController
     @expenses = @expenses.where("date <= ?", params[:date_to])   if params[:date_to].present?
     @expenses = @expenses.where(category_id: params[:category_id]) if params[:category_id].present?
     @expenses = @expenses.where("description ILIKE ?", "%#{params[:q]}%") if params[:q].present?
+    @selected_account_ref = selected_account_ref
   end
 
   # GET /expenses or /expenses.json

--- a/app/controllers/financial/entries_controller.rb
+++ b/app/controllers/financial/entries_controller.rb
@@ -1,10 +1,15 @@
 module Financial
   class EntriesController < ApplicationController
+    include Financial::AccountReferenceFiltering
+
     before_action :set_financial_entry, only: [ :show, :destroy ]
     before_action :load_form_collections, only: [ :new, :create ]
+    before_action :load_account_filter_options, only: [ :index ]
 
     def index
       @financial_entries = Financial::Entry.for_account(Current.account).by_date
+      @financial_entries = apply_account_ref_filter(@financial_entries)
+      @selected_account_ref = selected_account_ref
     end
 
     def show

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -20,6 +20,10 @@
       <label for="category_id" class="text-sm font-medium text-foreground"><%= t("expenses.index.category") %></label>
       <%= f.select :category_id, @categories.pluck(:name, :id), { include_blank: t("expenses.index.all_categories") }, id: "category_id", class: "rounded border border-input px-3 py-2 text-sm" %>
     </div>
+    <div class="flex flex-wrap items-center gap-2">
+      <label for="account_ref" class="text-sm font-medium text-foreground">Account</label>
+      <%= f.select :account_ref, @account_filter_options, { include_blank: "All accounts", selected: @selected_account_ref }, id: "account_ref", class: "rounded border border-input px-3 py-2 text-sm" %>
+    </div>
     <div class="flex flex-wrap items-center gap-2 flex-grow min-w-0">
       <label for="q" class="text-sm font-medium text-foreground sr-only"><%= t("expenses.index.description_placeholder") %></label>
       <%= f.text_field :q, placeholder: t("expenses.index.description_placeholder"), value: params[:q], id: "q", class: "rounded border border-input px-3 py-2 text-sm flex-1 min-w-0" %>

--- a/app/views/expenses/index.html.erb
+++ b/app/views/expenses/index.html.erb
@@ -18,7 +18,7 @@
     </div>
     <div class="flex flex-wrap items-center gap-2">
       <label for="category_id" class="text-sm font-medium text-foreground"><%= t("expenses.index.category") %></label>
-      <%= f.select :category_id, Category.all.pluck(:name, :id), { include_blank: t("expenses.index.all_categories") }, id: "category_id", class: "rounded border border-input px-3 py-2 text-sm" %>
+      <%= f.select :category_id, @categories.pluck(:name, :id), { include_blank: t("expenses.index.all_categories") }, id: "category_id", class: "rounded border border-input px-3 py-2 text-sm" %>
     </div>
     <div class="flex flex-wrap items-center gap-2 flex-grow min-w-0">
       <label for="q" class="text-sm font-medium text-foreground sr-only"><%= t("expenses.index.description_placeholder") %></label>

--- a/app/views/financial/entries/index.html.erb
+++ b/app/views/financial/entries/index.html.erb
@@ -2,6 +2,16 @@
 
 <h1 class="text-2xl font-bold mb-4">Financial Entries</h1>
 
+<%= form_with url: finance_financial_entries_path, method: :get, local: true, class: "mb-4 flex flex-col sm:flex-row sm:items-end gap-3" do |f| %>
+  <div class="flex flex-col gap-1">
+    <label for="account_ref" class="text-sm font-medium text-foreground">Account</label>
+    <%= f.select :account_ref, @account_filter_options, { include_blank: "All accounts", selected: @selected_account_ref }, id: "account_ref", class: "rounded border border-input px-3 py-2 text-sm" %>
+  </div>
+  <div>
+    <%= f.submit "Filter", class: "px-4 py-2 bg-primary text-white rounded text-sm font-medium cursor-pointer" %>
+  </div>
+<% end %>
+
 <div class="mb-4 flex justify-between items-center">
   <%= render Ui::ButtonComponent.new(
     href: new_finance_financial_entry_path,

--- a/test/controllers/expenses_controller_test.rb
+++ b/test/controllers/expenses_controller_test.rb
@@ -23,6 +23,28 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
       account: @account,
       budget_period: @budget_period
     )
+
+    @asset_a = Financial::Asset.create!(
+      account: @account,
+      name: "Checking A",
+      account_type: "checking",
+      status: "active",
+      opening_balance: 0
+    )
+    @asset_b = Financial::Asset.create!(
+      account: @account,
+      name: "Savings B",
+      account_type: "savings",
+      status: "active",
+      opening_balance: 0
+    )
+    @liability_a = Financial::Liability.create!(
+      account: @account,
+      name: "Visa",
+      liability_type: "credit_card",
+      status: "active",
+      opening_balance: 0
+    )
   end
 
   def sign_in
@@ -251,5 +273,171 @@ class ExpensesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "liability_payment", entry.entry_type
     assert_equal source_asset.id, entry.financial_account_id
     assert_equal destination_liability.id, entry.financial_liability_id
+  end
+
+  test "index filters expenses by asset account on source or counterparty side" do
+    sign_in
+
+    source_match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_a,
+      date: Date.current,
+      amount: 10,
+      description: "source match"
+    )
+    counterparty_match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_b,
+      counterparty_financial_account: @asset_a,
+      date: Date.current,
+      amount: 20,
+      description: "counterparty match"
+    )
+    non_match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_b,
+      date: Date.current,
+      amount: 30,
+      description: "non match"
+    )
+
+    get expenses_path, params: { account_ref: "asset:#{@asset_a.id}" }
+
+    assert_response :success
+    assert_select "option[value='asset:#{@asset_a.id}'][selected]"
+    assert_includes response.body, source_match.description
+    assert_includes response.body, counterparty_match.description
+    assert_not_includes response.body, non_match.description
+  end
+
+  test "index filters expenses by liability account on source or counterparty side" do
+    sign_in
+
+    source_match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_liability: @liability_a,
+      date: Date.current,
+      amount: 15,
+      description: "liability source match"
+    )
+    counterparty_match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_a,
+      counterparty_financial_liability: @liability_a,
+      date: Date.current,
+      amount: 25,
+      description: "liability counterparty match"
+    )
+    non_match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_a,
+      date: Date.current,
+      amount: 35,
+      description: "liability non match"
+    )
+
+    get expenses_path, params: { account_ref: "liability:#{@liability_a.id}" }
+
+    assert_response :success
+    assert_includes response.body, source_match.description
+    assert_includes response.body, counterparty_match.description
+    assert_not_includes response.body, non_match.description
+  end
+
+  test "index composes account filter with date category and description filters" do
+    sign_in
+
+    match = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_a,
+      date: Date.current,
+      amount: 22,
+      description: "target lunch"
+    )
+    wrong_description = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_a,
+      date: Date.current,
+      amount: 23,
+      description: "other text"
+    )
+    wrong_account = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_b,
+      date: Date.current,
+      amount: 24,
+      description: "target dinner"
+    )
+
+    get expenses_path, params: {
+      account_ref: "asset:#{@asset_a.id}",
+      date_from: Date.current,
+      date_to: Date.current,
+      category_id: @category.id,
+      q: "target"
+    }
+
+    assert_response :success
+    assert_includes response.body, match.description
+    assert_not_includes response.body, wrong_description.description
+    assert_not_includes response.body, wrong_account.description
+  end
+
+  test "index ignores malformed account_ref" do
+    sign_in
+
+    first = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_a,
+      date: Date.current,
+      amount: 11,
+      description: "first expense"
+    )
+    second = Expense.create!(
+      account: @account,
+      category: @category,
+      budget_period: @budget_period,
+      income_event: @income_event,
+      financial_account: @asset_b,
+      date: Date.current,
+      amount: 12,
+      description: "second expense"
+    )
+
+    get expenses_path, params: { account_ref: "oops" }
+
+    assert_response :success
+    assert_includes response.body, first.description
+    assert_includes response.body, second.description
   end
 end

--- a/test/controllers/financial/entries_controller_test.rb
+++ b/test/controllers/financial/entries_controller_test.rb
@@ -1,0 +1,148 @@
+require "test_helper"
+
+module Financial
+  class EntriesControllerTest < ActionDispatch::IntegrationTest
+    def setup
+      @user = users(:one)
+      @account = accounts(:one)
+      @category = categories(:one)
+      @income_event = income_events(:one)
+
+      @asset_a = Financial::Asset.create!(
+        account: @account,
+        name: "Wallet A",
+        account_type: "checking",
+        status: "active",
+        opening_balance: 0
+      )
+      @asset_b = Financial::Asset.create!(
+        account: @account,
+        name: "Wallet B",
+        account_type: "savings",
+        status: "active",
+        opening_balance: 0
+      )
+      @liability_a = Financial::Liability.create!(
+        account: @account,
+        name: "Mastercard",
+        liability_type: "credit_card",
+        status: "active",
+        opening_balance: 0
+      )
+    end
+
+    def sign_in
+      post session_path, params: {
+        email_address: @user.email_address,
+        password: "password"
+      }
+      Current.account = @account
+    end
+
+    def teardown
+      Current.account = nil
+      Current.session = nil
+    end
+
+    test "index filters entries by asset account on source or counterparty side" do
+      sign_in
+
+      source_match = Financial::Entry.create!(
+        account: @account,
+        entry_type: "outflow",
+        financial_account: @asset_a,
+        entry_date: Date.current,
+        amount: 10,
+        description: "entry source match"
+      )
+      counterparty_match = Financial::Entry.create!(
+        account: @account,
+        entry_type: "transfer",
+        financial_account: @asset_b,
+        counterparty_financial_account: @asset_a,
+        entry_date: Date.current,
+        amount: 20,
+        description: "entry counterparty match"
+      )
+      non_match = Financial::Entry.create!(
+        account: @account,
+        entry_type: "outflow",
+        financial_account: @asset_b,
+        entry_date: Date.current,
+        amount: 30,
+        description: "entry non match"
+      )
+
+      get finance_financial_entries_path, params: { account_ref: "asset:#{@asset_a.id}" }
+
+      assert_response :success
+      assert_select "select[name='account_ref'] option[value='asset:#{@asset_a.id}'][selected]"
+      assert_includes response.body, source_match.description
+      assert_includes response.body, counterparty_match.description
+      assert_not_includes response.body, non_match.description
+    end
+
+    test "index filters entries by liability account on source or counterparty side" do
+      sign_in
+
+      source_match = Financial::Entry.create!(
+        account: @account,
+        entry_type: "liability_charge",
+        financial_liability: @liability_a,
+        entry_date: Date.current,
+        amount: 40,
+        description: "liability source match"
+      )
+      counterparty_match = Financial::Entry.create!(
+        account: @account,
+        entry_type: "inflow",
+        counterparty_financial_liability: @liability_a,
+        entry_date: Date.current,
+        amount: 50,
+        description: "liability counterparty match"
+      )
+      non_match = Financial::Entry.create!(
+        account: @account,
+        entry_type: "outflow",
+        financial_account: @asset_a,
+        entry_date: Date.current,
+        amount: 60,
+        description: "liability non match"
+      )
+
+      get finance_financial_entries_path, params: { account_ref: "liability:#{@liability_a.id}" }
+
+      assert_response :success
+      assert_includes response.body, source_match.description
+      assert_includes response.body, counterparty_match.description
+      assert_not_includes response.body, non_match.description
+    end
+
+    test "index ignores malformed account_ref" do
+      sign_in
+
+      first = Financial::Entry.create!(
+        account: @account,
+        entry_type: "outflow",
+        financial_account: @asset_a,
+        entry_date: Date.current,
+        amount: 10,
+        description: "first visible entry"
+      )
+      second = Financial::Entry.create!(
+        account: @account,
+        entry_type: "outflow",
+        financial_account: @asset_b,
+        entry_date: Date.current,
+        amount: 10,
+        description: "second visible entry"
+      )
+
+      get finance_financial_entries_path, params: { account_ref: "bad-value" }
+
+      assert_response :success
+      assert_includes response.body, first.description
+      assert_includes response.body, second.description
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds a reusable financial account reference filter for expenses and financial entries.

It allows users to filter records by asset or liability account, making it easier to review expenses and ledger entries related to a specific financial account.

## Changes

- Added `Financial::AccountReferenceFiltering` concern to centralize account filter behavior.
- Added account filter options for active assets and liabilities.
- Added account reference parsing for values like `asset:1` and `liability:1`.
- Applied account filtering to:
  - `ExpensesController#index`
  - `Financial::EntriesController#index`
- Preserved the selected account filter value in the UI.
- Updated the expenses index filter form to include an account selector.
- Scoped expense categories by the current tenant account instead of using all categories.

## Why

Expenses and financial entries can reference assets or liabilities in different fields depending on the transaction type. This PR creates one shared filtering concern so both indexes can use the same behavior consistently.

It also improves tenant safety by ensuring expense category options are loaded from the current account only.

## Testing

- Verified expenses can be filtered by selected asset or liability account.
- Verified financial entries can be filtered by selected asset or liability account.
- Verified the selected filter remains visible after applying the search.
- Verified category options are scoped to the current account.