### PR TITLE
Enhance financial entry support and improve Turbo response handling

### DIFF
--- a/app/controllers/planned_expenses_controller.rb
+++ b/app/controllers/planned_expenses_controller.rb
@@ -73,12 +73,13 @@ class PlannedExpensesController < ApplicationController
     new_income_event_id = planned_expense_params[:income_event_id]
     requested_status = planned_expense_params[:status]
     final_status_requested = PlannedExpense.final_status?(requested_status)
+    should_execute_transaction = final_status_requested
     attrs = planned_expense_params
     attrs = attrs.except(:status) if final_status_requested
 
     respond_to do |format|
       if @planned_expense.update(attrs)
-        if final_status_requested
+        if should_execute_transaction
           execution = PlannedExpenses::ExecuteService.call(
             planned_expense: @planned_expense,
             target_status: requested_status
@@ -89,6 +90,7 @@ class PlannedExpensesController < ApplicationController
             @income_events = ordered_income_events_for_reference(@planned_expense.due_date)
             load_route_collections
             flash.now[:alert] = execution.error_message
+            format.turbo_stream { render :edit, status: :unprocessable_entity }
             format.html { render :edit, status: :unprocessable_entity }
             format.json { render json: { error: execution.error_message }, status: :unprocessable_entity }
             return
@@ -99,8 +101,10 @@ class PlannedExpensesController < ApplicationController
         if new_income_event_id.present? && new_income_event_id.to_i != old_income_event.id
           new_income_event = IncomeEvent.for_account(Current.account).find(new_income_event_id)
           move_planned_expense_to!(@planned_expense, new_income_event)
+          format.turbo_stream { redirect_to income_event_planned_expenses_path(new_income_event), notice: "Planned expense was successfully moved and updated." }
           format.html { redirect_to income_event_planned_expenses_path(new_income_event), notice: "Planned expense was successfully moved and updated." }
         else
+          format.turbo_stream { redirect_to income_event_planned_expenses_path(@income_event), notice: t("planned_expenses.flash.updated") }
           format.html { redirect_to income_event_planned_expenses_path(@income_event), notice: t("planned_expenses.flash.updated") }
         end
         format.json { render :show, status: :ok, location: [ @income_event, @planned_expense ] }
@@ -108,6 +112,7 @@ class PlannedExpensesController < ApplicationController
         @expense_templates = ExpenseTemplate.for_account(Current.account).includes(:category).all
         @income_events = ordered_income_events_for_reference(@planned_expense.due_date)
         load_route_collections
+        format.turbo_stream { render :edit, status: :unprocessable_entity }
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @planned_expense.errors, status: :unprocessable_entity }
       end
@@ -118,6 +123,7 @@ class PlannedExpensesController < ApplicationController
     @income_events = ordered_income_events_for_reference(@planned_expense.due_date)
     load_route_collections
     respond_to do |format|
+      format.turbo_stream { render :edit, status: :unprocessable_entity }
       format.html { render :edit, status: :unprocessable_entity }
       format.json { render json: @planned_expense.errors, status: :unprocessable_entity }
     end

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -78,6 +78,12 @@ module PlannedExpenses
         entry.financial_liability = planned_expense.financial_liability
         entry.counterparty_financial_account = nil
         entry.counterparty_financial_liability = nil
+      elsif planned_expense.financial_liability.present?
+        entry.entry_type = "liability_charge"
+        entry.financial_account = nil
+        entry.financial_liability = planned_expense.financial_liability
+        entry.counterparty_financial_account = nil
+        entry.counterparty_financial_liability = nil
       else
         entry.entry_type = "outflow"
         entry.financial_account = planned_expense.financial_account


### PR DESCRIPTION
## Summary

This PR improves planned expense transaction execution by supporting liability charge entries and adding Turbo Stream responses to the planned expense update flow.

## Changes

- Added support for creating `liability_charge` financial entries when a planned expense is linked directly to a liability.
- Updated `PlannedExpenses::ExecuteService#build_or_update_financial_entry!` to assign the correct entry type and account references for liability charges.
- Added Turbo Stream responses to `PlannedExpensesController#update`.
- Ensured validation and execution errors render the edit form correctly with `unprocessable_entity`.
- Added Turbo-compatible redirects after successful planned expense updates or moves.

## Why

Planned expenses can now represent liability charges, not only regular outflows, transfers, or liability payments. This makes the execution flow more complete and better aligned with the financial entry model.

The Turbo Stream responses also improve the UX by handling update errors and redirects correctly when the form is submitted through Turbo.

## Testing

- Verified planned expenses linked to liabilities create `liability_charge` entries.
- Verified update errors render the edit form with `422 Unprocessable Entity`.
- Verified successful updates and moves redirect correctly through Turbo and HTML responses.