### PR TITLE
Add edit/update functionality for financial entries and migration

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,96 @@
+# This file configures Herb for your project and team.
+# Settings here take precedence over individual editor preferences.
+#
+# Herb is a suite of tools for HTML+ERB templates including:
+# - Linter: Validates templates and enforces best practices
+# - Formatter: Auto-formats templates with intelligent indentation
+# - Language Server: Provides IDE support (VS Code, Zed, Neovim, etc.)
+#
+# Website: https://herb-tools.dev
+# Configuration: https://herb-tools.dev/configuration
+# GitHub Repo: https://github.com/marcoroth/herb
+#
+
+version: 0.10.1
+
+# # Framework and template engine configuration
+#
+# # Options: ruby | actionview | hanami | sinatra (default: ruby)
+# framework: ruby
+#
+# # Options: erubi | erb | herb (default: erubi)
+# template_engine: erubi
+
+# files:
+#   # Additional patterns beyond the defaults (**.html, **.rhtml, **.html.erb, etc.)
+#   include:
+#     - '**/*.xml.erb'
+#     - 'custom/**/*.html'
+#
+#   # Patterns to exclude (can exclude defaults too)
+#   exclude:
+#     - 'public/**/*'
+#     - 'tmp/**/*'
+
+# engine:
+#   validators:
+#     security: true       # default: true
+#     nesting: true        # default: true
+#     accessibility: true  # default: true
+
+linter:
+  enabled: true
+
+  # # Exit with error code when diagnostics of this severity or higher are present
+  # # Valid values: error (default), warning, info, hint
+  # failLevel: warning
+
+  # # Additional patterns beyond the defaults for linting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from linting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # rules:
+  #   erb-no-extra-newline:
+  #     enabled: false
+  #
+  #   # Rules can have 'include', 'only', and 'exclude' patterns
+  #   some-rule:
+  #     # Additional patterns to check (additive, ignored when 'only' is present)
+  #     include:
+  #       - 'app/components/**/*'
+  #     # Don't apply this rule to files matching these patterns
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+  #
+  #   another-rule:
+  #     # Only apply this rule to files matching these patterns (overrides all 'include')
+  #     only:
+  #       - 'app/views/**/*'
+  #     # Exclude still applies even with 'only'
+  #     exclude:
+  #       - 'app/views/admin/**/*'
+
+formatter:
+  enabled: false
+  indentWidth: 2
+  maxLineLength: 80
+
+  # # Additional patterns beyond the defaults for formatting
+  # include:
+  #   - '**/*.xml.erb'
+  #
+  # # Patterns to exclude from formatting
+  # exclude:
+  #   - 'app/views/admin/**/*'
+
+  # # Rewriters modify templates during formatting
+  # rewriter:
+  #   # Pre-format rewriters (modify AST before formatting)
+  #   pre:
+  #     - tailwind-class-sorter
+  #   # Post-format rewriters (modify formatted output string)
+  #   post: []

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "marcoroth.herb-lsp"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ The Previous Balance feature provides visibility into how financial deficits car
 6. Navigate to `http://localhost:3000` in your browser.
 
 ### Frontend tools
-
-If you're using the Node-based frontend tooling, a couple of helper scripts are available in `package.json`:
+run and fix linterns for .html.erb files:
 
 ```bash
 # Run the herb linter
@@ -150,7 +149,7 @@ npm run herb:lint
 # Run the herb linter with automatic fixes
 npm run herb:lint-fix
 ```
-
+[herb docs here](https://herb-tools.dev/projects/linter)
 ## Usage
 
 * **Dashboard**: Homepage shows quick links to manage budgets, income events, expenses, categories, shopping list, and inventory.

--- a/README.md
+++ b/README.md
@@ -139,6 +139,18 @@ The Previous Balance feature provides visibility into how financial deficits car
 
 6. Navigate to `http://localhost:3000` in your browser.
 
+### Frontend tools
+
+If you're using the Node-based frontend tooling, a couple of helper scripts are available in `package.json`:
+
+```bash
+# Run the herb linter
+npm run herb:lint
+
+# Run the herb linter with automatic fixes
+npm run herb:lint-fix
+```
+
 ## Usage
 
 * **Dashboard**: Homepage shows quick links to manage budgets, income events, expenses, categories, shopping list, and inventory.

--- a/app/controllers/financial/entries_controller.rb
+++ b/app/controllers/financial/entries_controller.rb
@@ -30,6 +30,17 @@ module Financial
       end
     end
 
+    def edit
+    end
+
+    def update
+      if @financial_entry.update(financial_entry_params)
+        redirect_to finance_financial_entry_path(@financial_entry), notice: "Entry updated"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
     def destroy
       @financial_entry.destroy!
       redirect_to finance_financial_entries_path, status: :see_other, notice: "Entry removed"

--- a/app/controllers/financial/entries_controller.rb
+++ b/app/controllers/financial/entries_controller.rb
@@ -2,8 +2,8 @@ module Financial
   class EntriesController < ApplicationController
     include Financial::AccountReferenceFiltering
 
-    before_action :set_financial_entry, only: [ :show, :destroy ]
-    before_action :load_form_collections, only: [ :new, :create ]
+    before_action :set_financial_entry, only: [ :show, :edit, :update, :destroy ]
+    before_action :load_form_collections, only: [ :new, :create, :edit, :update ]
     before_action :load_account_filter_options, only: [ :index ]
 
     def index

--- a/app/controllers/quick_add_controller.rb
+++ b/app/controllers/quick_add_controller.rb
@@ -81,7 +81,8 @@ class QuickAddController < ApplicationController
     from_type, from_id = parse_financial_type(params.dig(:transfer, :from_type))
     to_type, to_id = parse_financial_type(params.dig(:transfer, :to_type))
 
-    if from_type.nil? || to_type.nil? || from_id == to_id
+    same_endpoint = from_type == to_type && from_id == to_id
+    if from_type.nil? || to_type.nil? || same_endpoint
       return render plain: "Please choose valid and different origin/destination accounts", status: :unprocessable_entity
     end
 

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -6,7 +6,7 @@ module PlannedExpenses
       new(...).call
     end
 
-    def initialize(planned_expense:, entry_date: Date.current, target_status: nil)
+    def initialize(planned_expense:, entry_date: nil, target_status: nil)
       @planned_expense = planned_expense
       @entry_date = entry_date
       @target_status = target_status

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -16,6 +16,7 @@ module PlannedExpenses
       return failure("Planned expense is required") if planned_expense.blank?
 
       ActiveRecord::Base.transaction do
+        execution_date = resolved_entry_date
         expense = build_or_update_expense_if_needed
         entry = build_or_update_financial_entry!(expense: expense)
 

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -21,6 +21,9 @@ module PlannedExpenses
         entry = build_or_update_financial_entry!(expense: expense, execution_date: execution_date)
 
         planned_expense.update!(status: status_after_execution) unless planned_expense.status == status_after_execution
+        if PlannedExpense.final_status?(status_after_execution) && planned_expense.applied_on.blank?
+          planned_expense.update!(applied_on: execution_date)
+        end
 
         Result.new(success?: true, planned_expense: planned_expense, expense: expense, entry: entry)
       end

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -108,6 +108,14 @@ module PlannedExpenses
       "paid"
     end
 
+    def resolved_entry_date
+      return entry_date if entry_date.present?
+      return planned_expense.applied_on if planned_expense.applied_on.present?
+      return planned_expense.due_date if planned_expense.due_date.present? && planned_expense.final_status?
+
+      Date.current
+    end
+
     def failure(message)
       Result.new(success?: false, error_message: message, planned_expense: planned_expense)
     end

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -18,7 +18,7 @@ module PlannedExpenses
       ActiveRecord::Base.transaction do
         execution_date = resolved_entry_date
         expense = build_or_update_expense_if_needed
-        entry = build_or_update_financial_entry!(expense: expense)
+        entry = build_or_update_financial_entry!(expense: expense, execution_date: execution_date)
 
         planned_expense.update!(status: status_after_execution) unless planned_expense.status == status_after_execution
 

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -56,13 +56,13 @@ module PlannedExpenses
       expense
     end
 
-    def build_or_update_financial_entry!(expense:)
+    def build_or_update_financial_entry!(expense:, execution_date:)
       entry = Financial::Entry.find_by(planned_expense_id: planned_expense.id) || planned_expense.financial_entry || Financial::Entry.new
       entry.account = planned_expense.account
       entry.income_event = planned_expense.income_event
       entry.planned_expense = planned_expense
       entry.expense = expense if expense.present?
-      entry.entry_date = entry_date
+      entry.entry_date = execution_date
       entry.amount = planned_expense.amount
       entry.description = planned_expense.description
 

--- a/app/services/planned_expenses/execute_service.rb
+++ b/app/services/planned_expenses/execute_service.rb
@@ -37,7 +37,7 @@ module PlannedExpenses
 
     def expense_attributes
       {
-        date: entry_date,
+        date: resolved_entry_date,
         amount: planned_expense.amount,
         description: planned_expense.description,
         category: planned_expense.category,

--- a/app/views/financial/entries/_form.html.erb
+++ b/app/views/financial/entries/_form.html.erb
@@ -1,4 +1,6 @@
-<%= form_with model: @financial_entry, url: finance_financial_entries_path, local: true do |form| %>
+<% form_url = @financial_entry.persisted? ? finance_financial_entry_path(@financial_entry) : finance_financial_entries_path %>
+<% form_method = @financial_entry.persisted? ? :patch : :post %>
+<%= form_with model: @financial_entry, url: form_url, method: form_method, local: true do |form| %>
   <% if @financial_entry.errors.any? %>
     <div class="bg-danger-soft border border-danger-soft text-danger px-4 py-3 rounded mb-4">
       <h2 class="font-bold"><%= pluralize(@financial_entry.errors.count, "error") %> prohibited this record from being saved:</h2>

--- a/app/views/financial/entries/edit.html.erb
+++ b/app/views/financial/entries/edit.html.erb
@@ -1,0 +1,3 @@
+<h1 class="text-2xl font-bold mb-4">Edit Financial Entry</h1>
+
+<%= render "form" %>

--- a/app/views/financial/entries/show.html.erb
+++ b/app/views/financial/entries/show.html.erb
@@ -27,6 +27,11 @@
 
 <div class="mb-4 flex space-x-2">
   <%= render Ui::ButtonComponent.new(
+    href: edit_finance_financial_entry_path(@financial_entry),
+    label: "Edit",
+    variant: "outline"
+  ) %>
+  <%= render Ui::ButtonComponent.new(
     href: finance_financial_entry_path(@financial_entry),
     label: "Delete",
     variant: "destructive",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,7 @@ Rails.application.routes.draw do
         post :record_payment
       end
     end
-    resources :financial_entries, only: [ :index, :show, :new, :create, :destroy ], controller: "/financial/entries"
+    resources :financial_entries, only: [ :index, :show, :new, :create, :edit, :update, :destroy ], controller: "/financial/entries"
   end
   scope module: "financial" do
     resources :budget_periods do

--- a/db/migrate/20260522170000_add_applied_on_to_planned_expenses.rb
+++ b/db/migrate/20260522170000_add_applied_on_to_planned_expenses.rb
@@ -1,0 +1,6 @@
+class AddAppliedOnToPlannedExpenses < ActiveRecord::Migration[8.1]
+  def change
+    add_column :planned_expenses, :applied_on, :date
+    add_index :planned_expenses, :applied_on
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_14_102000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_22_170000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -366,6 +366,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_102000) do
   create_table "planned_expenses", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.decimal "amount", precision: 10, scale: 2, null: false
+    t.date "applied_on"
     t.bigint "category_id", null: false
     t.bigint "counterparty_financial_account_id"
     t.datetime "created_at", null: false
@@ -383,6 +384,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_14_102000) do
     t.string "status", null: false
     t.datetime "updated_at", null: false
     t.index ["account_id"], name: "index_planned_expenses_on_account_id"
+    t.index ["applied_on"], name: "index_planned_expenses_on_applied_on"
     t.index ["category_id"], name: "index_planned_expenses_on_category_id"
     t.index ["counterparty_financial_account_id"], name: "index_planned_expenses_on_counterparty_financial_account_id"
     t.index ["expense_template_id"], name: "index_planned_expenses_on_expense_template_id"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,466 @@
+{
+  "name": "open-budget",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@herb-tools/linter": "^0.10.1"
+      }
+    },
+    "node_modules/@herb-tools/config": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/config/-/config-0.10.1.tgz",
+      "integrity": "sha512-eaC7N1uDsDhqaEh+ulvw77mEsYYpBnU5mb6cSm86U8YYErnEIq5Rp3H9uqVs4HQmvc7NXhZVIDNaSciAKJVJaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.1",
+        "picomatch": "^4.0.4",
+        "tinyglobby": "^0.2.16",
+        "yaml": "^2.8.3"
+      }
+    },
+    "node_modules/@herb-tools/core": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/core/-/core-0.10.1.tgz",
+      "integrity": "sha512-zFVhWGvqC7b5KHtp4LNlCt4ExLInuRZJxvcNp9kcHCAwnVux+EiXnJz8rsiiF8pU1z2gjq3w6q/g7ayjOetpAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@herb-tools/highlighter": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/highlighter/-/highlighter-0.10.1.tgz",
+      "integrity": "sha512-zgDNj9T/vHaN+V29KqnKXJJMG7eF9GWjYj03VeoDXCkiWbeVJ1G0RKsNuW6QcziyXYeIEyVpS/A3EUvg+Annow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.1",
+        "@herb-tools/node-wasm": "0.10.1"
+      },
+      "bin": {
+        "herb-highlight": "bin/herb-highlight"
+      }
+    },
+    "node_modules/@herb-tools/linter": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/linter/-/linter-0.10.1.tgz",
+      "integrity": "sha512-2K+8PJ6FbS8+nrR7IaMTLdlyO5Ci/dAd4lOngvQMvuwoCiYysvAtTeSySSJtAhgL2YhlneLM+Crw1QN3AsnC2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/config": "0.10.1",
+        "@herb-tools/core": "0.10.1",
+        "@herb-tools/highlighter": "0.10.1",
+        "@herb-tools/node-wasm": "0.10.1",
+        "@herb-tools/printer": "0.10.1",
+        "@herb-tools/rewriter": "0.10.1",
+        "picomatch": "^4.0.4",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "herb-lint": "bin/herb-lint"
+      }
+    },
+    "node_modules/@herb-tools/node-wasm": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/node-wasm/-/node-wasm-0.10.1.tgz",
+      "integrity": "sha512-dKMpscMLdBEgJnPmkBVT0iEkjssgjOUsJCpKWi2HMqZEsIem4NR9j3v7D5aq8cR5W80y/7dvNmHtefAsLt8KSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.1"
+      }
+    },
+    "node_modules/@herb-tools/printer": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/printer/-/printer-0.10.1.tgz",
+      "integrity": "sha512-qxE/8G5xnEMKWkSQbWxQZplFJcvs2v2XFR3WEXSVfVQUtpgy/vLJPMAZI4kVDTF+MfdxVzCUZVEeL+OXYzfPCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "herb-print": "bin/herb-print"
+      }
+    },
+    "node_modules/@herb-tools/rewriter": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/rewriter/-/rewriter-0.10.1.tgz",
+      "integrity": "sha512-XNBrh03gwNHMwlR3XID7hM3z1kfNtwF9+hURqHPlBURr3OFFa1DDo3pFTpowLC8/d6NWkj9Nb8g8f7nCWAZa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@herb-tools/core": "0.10.1",
+        "@herb-tools/tailwind-class-sorter": "0.10.1",
+        "tinyglobby": "^0.2.15"
+      }
+    },
+    "node_modules/@herb-tools/tailwind-class-sorter": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@herb-tools/tailwind-class-sorter/-/tailwind-class-sorter-0.10.1.tgz",
+      "integrity": "sha512-+ie6BMM5wONUuLPjsEYjZ2wfKFLG637UCpdcT49Z8Pucs3auk+uBIleQK1+NI1229txUxMOqnp0VJ5LbCuXQYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clear-module": "^4.1.2",
+        "escalade": "^3.2.0",
+        "jiti": "^2.5.1",
+        "postcss": "^8.5.10",
+        "postcss-import": "^16.1.1"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": "^3.0 || ^4.0"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clear-module": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/clear-module/-/clear-module-4.1.3.tgz",
+      "integrity": "sha512-XdLrg7BnbXKntyrbs2dNjDN9CVoTQ+WV0i7jT5/r9ahzAaSDSzC9e2OVZB/QVwbxBb1/1AeObzjlxsYk5HFvww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^2.0.0",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-2.0.0.tgz",
+      "integrity": "sha512-uo0Z9JJeWzv8BG+tRcapBKNJ0dro9cLyczGzulS6EfeyAdeC9sbojtW6XwvYxJkEne9En+J2XEl4zyglVeIwFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-import": {
+      "version": "16.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
+      "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
+      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@herb-tools/linter": "^0.10.1"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
  "scripts": {
-    "herb:lint":"herb-lint"
+    "herb:lint":"herb-lint",
+    "herb:lint-fix":"npx @herb-tools/linter --fix"
  },
   "devDependencies": {
     "@herb-tools/linter": "^0.10.1"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+ "scripts": {
+    "herb:lint":"herb-lint"
+ },
   "devDependencies": {
     "@herb-tools/linter": "^0.10.1"
   }

--- a/test/controllers/quick_add_controller_test.rb
+++ b/test/controllers/quick_add_controller_test.rb
@@ -106,6 +106,64 @@ class QuickAddControllerTest < ActionDispatch::IntegrationTest
     assert_equal 160.to_d, @liability.reload.current_balance
   end
 
+  test "quick add transfer allows same numeric id when account types differ (asset to liability)" do
+    asset_max_id = Financial::Asset.for_account(@account).maximum(:id).to_i
+    liability_max_id = Financial::Liability.for_account(@account).maximum(:id).to_i
+
+    if asset_max_id > liability_max_id
+      (asset_max_id - liability_max_id).times do |i|
+        Financial::Liability.create!(
+          account: @account,
+          name: "Liability align #{i}",
+          liability_type: "credit_card",
+          status: "active",
+          opening_balance: 100
+        )
+      end
+    elsif liability_max_id > asset_max_id
+      (liability_max_id - asset_max_id).times do |i|
+        Financial::Asset.create!(
+          account: @account,
+          name: "Asset align #{i}",
+          account_type: "checking",
+          status: "active",
+          opening_balance: 100
+        )
+      end
+    end
+
+    overlap_asset = Financial::Asset.create!(
+      account: @account,
+      name: "Asset overlap deterministic",
+      account_type: "checking",
+      status: "active",
+      opening_balance: 100
+    )
+    overlap_liability = Financial::Liability.create!(
+      account: @account,
+      name: "Liability overlap deterministic",
+      liability_type: "credit_card",
+      status: "active",
+      opening_balance: 100
+    )
+
+    assert_equal overlap_asset.id, overlap_liability.id, "Expected asset/liability id overlap for deterministic edge-case coverage"
+
+    assert_difference -> { Financial::Entry.count }, 1 do
+      post quick_add_create_transfer_path, params: {
+        transfer: {
+          amount: 25,
+          from_type: "asset_#{overlap_asset.id}",
+          to_type: "liability_#{overlap_liability.id}"
+        }
+      }
+    end
+
+    assert_response :created
+    assert_equal 75.to_d, overlap_asset.reload.current_balance
+    assert_equal 75.to_d, overlap_liability.reload.current_balance
+  end
+
   test "quick add income to liability reduces liability balance" do
     assert_difference -> { Financial::Entry.count }, 1 do
       post quick_add_create_income_path, params: {


### PR DESCRIPTION
## Summary

This PR adds support for editing financial entries, tracks when planned expenses are applied, and introduces Herb tooling for HTML/ERB linting.

## Changes

- Added `applied_on` to planned expenses with a database index.
- Updated `PlannedExpenses::ExecuteService` to resolve and reuse the correct execution date.
- Stored the execution date on `planned_expense.applied_on` when a planned expense reaches a final status.
- Updated financial entries and expenses created from planned expenses to use the resolved execution date.
- Added `edit` and `update` actions for financial entries.
- Added edit/update routes for financial entries.
- Added a financial entry edit view and reused the existing form for both create and update flows.
- Added an edit button to the financial entry show page.
- Added Herb configuration for HTML/ERB linting.
- Added npm scripts to run and auto-fix Herb linting issues.
- Documented Herb linting commands and linked the Herb documentation in the README.

## Why

Planned expense execution now keeps a dedicated applied date, making the generated expense or financial entry date easier to control and reason about.

Financial entries can also be edited after creation, which improves data correction workflows.

Herb tooling gives the project a consistent way to lint ERB templates and catch view-level issues earlier.

## Testing

- Ran the database migration.
- Verified financial entries can be edited and updated.
- Verified planned expense execution stores and uses the resolved applied date.
- Verified Herb linting commands are available through npm scripts.