### PR TITLE
Refactor ScheduleGenerator to use class compact syntax

### DIFF
--- a/app/services/loans/schedule_generator.rb
+++ b/app/services/loans/schedule_generator.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+  # frozen_string_literal: true
 
   class Loans::ScheduleGenerator
     PERIODS_PER_YEAR = {

--- a/app/services/loans/schedule_generator.rb
+++ b/app/services/loans/schedule_generator.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-module Loans
-  class ScheduleGenerator
+  class Loans::ScheduleGenerator
     PERIODS_PER_YEAR = {
       "weekly" => 52.0,
       "biweekly" => 26.0,
@@ -175,4 +174,3 @@ module Loans
 
     private_class_method :solve_periodic_rate, :payment_for_rate
   end
-end


### PR DESCRIPTION
ON `services/loans/schedule_generator.`
- adds Loans:: Prefix before class declaration to keep it compact